### PR TITLE
th-desugar.cabal: add missing file for tests into tarball

### DIFF
--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -47,6 +47,7 @@ test-suite spec
   ghc-options:        -Wall -Werror -main-is Test.Run
   default-language:   Haskell2010
   main-is:            Test/Run.hs
+  other-modules:      Test.Splices
 
   build-depends:
       base >= 4 && < 5,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
