### PR TITLE
nameBase GHC.Types.~ returns "~", not "(~)"

### DIFF
--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -188,7 +188,7 @@ predToTH = go []
     go _   (DVarPr _)
       = error "Template Haskell in GHC <= 7.8 does not support variable constraints."
     go acc (DConPr n) 
-      | nameBase n == "(~)"
+      | nameBase n == "(~)" || nameBase n == "~"
       , [t1, t2] <- acc
       = EqualP t1 t2
       | otherwise


### PR DESCRIPTION
I'm not sure if this is rarely used code, the behavior changed with different versions of GHC, or something else.
