### PR TITLE
Fix when building with template-haskell-2.10.0.0

### DIFF
--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -14,7 +14,7 @@
 --
 ----------------------------------------------------------------------------
 
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP, TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Language.Haskell.TH.Desugar.Lift () where
@@ -22,7 +22,9 @@ module Language.Haskell.TH.Desugar.Lift () where
 import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Lift
 import Language.Haskell.TH
+#if !(MIN_VERSION_template_haskell(2,10,0))
 import Data.Word
+#endif
 
 $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DKind, ''DPred, ''DTyVarBndr
                  , ''DMatch, ''DClause, ''DLetDec, ''DDec, ''DCon
@@ -32,7 +34,9 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DKind, ''DPred, ''DTyVarBndr
                  , ''Callconv, ''Safety, ''Inline, ''RuleMatch, ''Phases
                  , ''AnnTarget, ''FunDep, ''FamFlavour, ''Role ])
 
+#if !(MIN_VERSION_template_haskell(2,10,0))
 -- Other type liftings:
                                       
 instance Lift Word8 where
   lift word = return $ (VarE 'fromInteger) `AppE` (LitE $ IntegerL (toInteger word))
+#endif

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -9,8 +9,12 @@ more nested patterns.
 This code is directly based on the analogous operation as written in GHC.
 -}
 
-{-# LANGUAGE TemplateHaskell, StandaloneDeriving #-}
+{-# LANGUAGE CPP, TemplateHaskell #-}
+
+#if !(MIN_VERSION_template_haskell(2,10,0))
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}   -- we need Ord Lit. argh.
+#endif
 
 module Language.Haskell.TH.Desugar.Match (scExp, scLetDec) where
 
@@ -109,7 +113,9 @@ simplCase vars@(v:_) clauses = do
 
     drop_group = map snd
 
+#if !(MIN_VERSION_template_haskell(2,10,0))
 deriving instance Ord Lit   -- ew. necessary for `subGroup`
+#endif
 
 -- analogous to GHC's tidyEqnInfo
 tidyClause :: DsMonad q => Name -> EquationInfo -> q (DExp -> DExp, EquationInfo)


### PR DESCRIPTION
`template-haskell-2.10.0.0` provides instances for `Ord Lit` and `Lift Word8`, so only define those instances if using a version of `template-haskell` older than 2.10.0.0.