### PR TITLE
Convert (~) back to EqualityT in typeToTH

### DIFF
--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -7,6 +7,7 @@ Converts desugared TH back into real TH.
 -}
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -176,6 +177,7 @@ typeToTH (DVarT n)              = VarT n
 #if __GLASGOW_HASKELL__ >= 709
 typeToTH (DConT n) | n == ''(~) = EqualityT
 #endif
+typeToTH (DConT n) | n == ''[] = ListT
 typeToTH (DConT n)              = ConT n
 typeToTH DArrowT                = ArrowT
 typeToTH (DLitT lit)            = LitT lit

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -173,6 +173,9 @@ typeToTH (DForallT tvbs cxt ty) = ForallT (map tvbToTH tvbs) (map predToTH cxt) 
 typeToTH (DAppT t1 t2)          = AppT (typeToTH t1) (typeToTH t2)
 typeToTH (DSigT ty ki)          = SigT (typeToTH ty) (kindToTH ki)
 typeToTH (DVarT n)              = VarT n
+#if __GLASGOW_HASKELL__ >= 709
+typeToTH (DConT n) | n == ''(~) = EqualityT
+#endif
 typeToTH (DConT n)              = ConT n
 typeToTH DArrowT                = ArrowT
 typeToTH (DLitT lit)            = LitT lit

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -37,6 +37,7 @@ import Language.Haskell.TH hiding (cxt)
 import Language.Haskell.TH.Desugar.Core
 import Language.Haskell.TH.Desugar.Util
 
+import Data.List ( stripPrefix )
 import Data.Maybe ( maybeToList )
 
 expToTH :: DExp -> Exp
@@ -178,9 +179,13 @@ typeToTH (DVarT n)              = VarT n
 typeToTH (DConT n) | n == ''(~) = EqualityT
 #endif
 typeToTH (DConT n) | n == ''[] = ListT
-typeToTH (DConT n)              = ConT n
+typeToTH (DConT n)              = maybe (ConT n) TupleT (parseTupleFunctionName n)
 typeToTH DArrowT                = ArrowT
 typeToTH (DLitT lit)            = LitT lit
+
+parseTupleFunctionName :: Name -> Maybe Int
+parseTupleFunctionName n =
+    fmap ((2 +) . length . takeWhile (== ',')) (stripPrefix "(," (nameBase n))
 
 tvbToTH :: DTyVarBndr -> TyVarBndr
 tvbToTH (DPlainTV n)           = PlainTV n


### PR DESCRIPTION
This corresponds to

    #if __GLASGOW_HASKELL__ >= 709
    dsType EqualityT = return $ DConT ''(~)
    #endif

in the dsType function.