### PR TITLE
Build and pass tests on GHC 8

### DIFF
--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -28,6 +28,9 @@ module Language.Haskell.TH.Desugar (
   DCon(..), DConFields(..), DStrictType, DVarStrictType, DForeign(..),
   DPragma(..), DRuleBndr(..), DTySynEqn(..), DInfo(..), DInstanceDec,
   Role(..), AnnTarget(..),
+#if __GLASGOW_HASKELL__ > 710
+  DFamilyResultSig (..),
+#endif
 
   -- * The 'Desugar' class
   Desugar(..),
@@ -177,6 +180,7 @@ fvDType = go
     go (DConT _)               = S.empty
     go DArrowT                 = S.empty
     go (DLitT {})              = S.empty
+    go (DWildCardT _)          = S.empty -- FIXME: Wildcards cannot be bound, but are they free?
 
 dtvbName :: DTyVarBndr -> S.Set Name
 dtvbName (DPlainTV n)    = S.singleton n
@@ -190,6 +194,7 @@ fvDKind = go
     go (DConK _ kis)       = foldMap fvDKind kis
     go (DArrowK k1 k2)     = go k1 `S.union` go k2
     go DStarK              = S.empty
+    go (DWildCardK _)      = S.empty -- FIXME: Wildcards cannot be bound, but are they free? 
 
 -- | Produces 'DLetDec's representing the record selector functions from
 -- the provided 'DCon'.

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -930,12 +930,12 @@ dsPred ConstraintT =
 dsPred t@(LitT _) =
   impossible $ "Type literal seen as head of constraint: " ++ show t
 dsPred EqualityT = return [DConPr ''(~)]
-#endif
 #if __GLASGOW_HASKELL__ > 710
 dsPred (InfixT t1 n t2) = (:[]) <$> (DAppPr <$> (DAppPr (DConPr n) <$> dsType t1) <*> dsType t2)
 dsPred (UInfixT _ _ _) = fail "Cannot desugar unresolved infix operators."
 dsPred (ParensT t) = dsPred t
 dsPred (WildCardT m_n) = return [DWildCardPr m_n]
+#endif
 #endif
 
 -- | Desugar a kind

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -30,4 +30,7 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DKind, ''DPred, ''DTyVarBndr
 #if __GLASGOW_HASKELL__ < 707
                  , ''AnnTarget, ''Role
 #endif
+#if __GLASGOW_HASKELL__ > 710
+                 , ''DFamilyResultSig
+#endif
                  ])

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -234,11 +234,11 @@ predToTH (DAppPr p t) = AppT (predToTH p) (typeToTH t)
 predToTH (DSigPr p k) = SigT (predToTH p) (kindToTH k)
 predToTH (DVarPr n)   = VarT n
 predToTH (DConPr n)   = typeToTH (DConT n)
-#endif
 #if __GLASGOW_HASKELL__ > 710
 predToTH (DWildCardPr n) = WildCardT n
 #else
 predToTH (DWildCardPr _) = error "Wildcards supported only in GHC 8.0+"
+#endif
 #endif
 
 kindToTH :: DKind -> Kind

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -229,6 +229,8 @@ predToTH = go []
       = EqualP t1 t2
       | otherwise
       = ClassP n acc
+    go _ (DWildCardPr _)
+      = error "Wildcards supported only in GHC 8.0+"
 #else
 predToTH (DAppPr p t) = AppT (predToTH p) (typeToTH t)
 predToTH (DSigPr p k) = SigT (predToTH p) (kindToTH k)

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -159,8 +159,13 @@ test_mkName = and [ hasSameType (Proxy :: Proxy FuzzSyn) (Proxy :: Proxy Fuzz)
 
 test_bug8884 :: Bool
 test_bug8884 = $(do info <- reify ''Poly
+#if __GLASGOW_HASKELL__ > 710
+                    dinfo@(DTyConI (DOpenTypeFamilyD _name _tvbs (DKindSig resK) _ann)
+                                   (Just [DTySynInstD _name2 (DTySynEqn lhs _rhs)]))
+#else
                     dinfo@(DTyConI (DFamilyD TypeFam _name _tvbs (Just resK))
                                    (Just [DTySynInstD _name2 (DTySynEqn lhs _rhs)]))
+#endif
                       <- dsInfo info
                     case (resK, lhs) of
 #if __GLASGOW_HASKELL__ < 709

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -306,8 +306,13 @@ rec_sel_test_num_sels = 4 :: Int   -- exclude naughty one
 
 testRecSelTypes :: Int -> Q Exp
 testRecSelTypes n = do
+#if __GLASGOW_HASKELL__ > 710
+  VarI _ ty1 _ <- reify (mkName ("DsDec.recsel" ++ show n))
+  VarI _ ty2 _ <- reify (mkName ("Dec.recsel"   ++ show n))
+#else
   VarI _ ty1 _ _ <- reify (mkName ("DsDec.recsel" ++ show n))
   VarI _ ty2 _ _ <- reify (mkName ("Dec.recsel"   ++ show n))
+#endif
   let ty1' = return $ unqualify ty1
       ty2' = return $ unqualify ty2
   [| let x :: $ty1'


### PR DESCRIPTION
Trying to get my own libraries to build against GHC 8, I needed to update dependencies also. `th-desugar` took the longest to port, so I thought I'd share my results.

See this PR more as a guideline/head start on actually getting `th-desugar` to build on GHC 8, not as something that needs to be merged.