### PR TITLE
Build on GHC 8.0-rc1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 `th-desugar` release notes
 ==========================
 
+Version 1.6
+-----------
+* Work with GHC 8, with thanks to @christiaanb for getting this change going.
+
+* `DKind` is merged with `DType`.
+
+* `Generic` instances for everything.
+
 Version 1.5.5
 -------------
 

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -131,7 +131,7 @@ instance Desugar Con [DCon] where
   sweeten dcons = go [] cons
     where
       cons = map conToTH dcons
-#if MIN_VERSION_template_haskell(2,11,0)
+#if __GLASGOW_HASKELL__ > 710
       go nms [GadtC n stys rty]
         = GadtC (reverse (n ++ nms)) stys rty
       go nms [RecGadtC n vstys rty]
@@ -139,7 +139,7 @@ instance Desugar Con [DCon] where
 #endif
       go _   [c]
         = c
-#if MIN_VERSION_template_haskell(2,11,0)
+#if __GLASGOW_HASKELL__ > 710
       go nms (GadtC n1 stys1 rty1:GadtC n2 stys2 rty2:cons')
         | stys1 == stys2
         , rty1  == rty2

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -694,7 +694,7 @@ dsDec d@(ValD {}) = (fmap . map) DLetDec $ dsLetDec d
 dsDec (DataD cxt n tvbs mk cons derivings) =
   (:[]) <$> (DDataD Data <$> dsCxt cxt <*> pure n
                          <*> mapM dsTvb tvbs <*> mapM dsKind mk
-                         <*> (concat <$> mapM dsCon cons)
+                         <*> concatMapM dsCon cons
                          <*> dsCxt derivings)
 dsDec (NewtypeD cxt n tvbs mk con derivings) =
   (:[]) <$> (DDataD Newtype <$> dsCxt cxt <*> pure n
@@ -703,7 +703,7 @@ dsDec (NewtypeD cxt n tvbs mk con derivings) =
 #else
 dsDec (DataD cxt n tvbs cons derivings) =
   (:[]) <$> (DDataD Data <$> dsCxt cxt <*> pure n
-                         <*> mapM dsTvb tvbs <*> (concat <$> mapM dsCon cons)
+                         <*> mapM dsTvb tvbs <*> concatMapM dsCon cons
                          <*> pure derivings)
 dsDec (NewtypeD cxt n tvbs con derivings) =
   (:[]) <$> (DDataD Newtype <$> dsCxt cxt <*> pure n
@@ -733,7 +733,7 @@ dsDec (FamilyD flav n tvbs m_k) =
 #if MIN_VERSION_template_haskell(2,11,0)
 dsDec (DataInstD cxt n tys mk cons derivings) =
   (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n <*> mapM dsType tys
-                             <*> mapM dsKind mk <*> (concat <$> mapM dsCon cons)
+                             <*> mapM dsKind mk <*> concatMapM dsCon cons
                              <*> dsCxt derivings)
 dsDec (NewtypeInstD cxt n tys mk con derivings) =
   (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n <*> mapM dsType tys
@@ -742,7 +742,7 @@ dsDec (NewtypeInstD cxt n tys mk con derivings) =
 #else
 dsDec (DataInstD cxt n tys cons derivings) =
   (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n <*> mapM dsType tys
-                             <*> (concat <$> mapM dsCon cons) <*> pure derivings)
+                             <*> concatMapM dsCon cons <*> pure derivings)
 dsDec (NewtypeInstD cxt n tys con derivings) =
   (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n <*> mapM dsType tys
                                 <*> dsCon con <*> pure derivings)

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -671,7 +671,7 @@ remove_arrows _ frs = return frs
 
 remove_arrows' :: DsMonad q => Int -> DKind -> q DKind
 remove_arrows' 0 k = return k
-remove_arrows' n (DArrowK _ k) = remove_arrows' (n-1) k
+remove_arrows' n (DArrowT _ k) = remove_arrows' (n-1) k
 remove_arrows' _ _ =
   impossible "Internal error: Fix for bug 8884 ran out of arrows."
 

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -655,7 +655,7 @@ fixBug8884ForFamilies (DOpenTypeFamilyD (DTypeFamilyHead name tvbs frs ann)) = d
 fixBug8884ForFamilies (DClosedTypeFamilyD (DTypeFamilyHead name tvbs frs ann) eqns) = do
   let num_args = length tvbs
       eqns' = map (fixBug8884ForEqn num_args) eqns
-  frs' <- mapM (remove_arrows num_args) frs
+  frs' <- remove_arrows num_args frs
   return (DClosedTypeFamilyD (DTypeFamilyHead name tvbs frs' ann) eqns', num_args)
 fixBug8884ForFamilies dec@(DDataFamilyD name tvbs) = do
   let num_args = length tvbs

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -657,7 +657,7 @@ fixBug8884ForFamilies (DClosedTypeFamilyD (DTypeFamilyHead name tvbs frs ann) eq
       eqns' = map (fixBug8884ForEqn num_args) eqns
   frs' <- remove_arrows num_args frs
   return (DClosedTypeFamilyD (DTypeFamilyHead name tvbs frs' ann) eqns', num_args)
-fixBug8884ForFamilies dec@(DDataFamilyD name tvbs) = do
+fixBug8884ForFamilies dec@(DDataFamilyD _ tvbs) = do
   let num_args = length tvbs
   return (dec, num_args)
 fixBug8884ForFamilies dec =

--- a/Language/Haskell/TH/Desugar/Expand.hs
+++ b/Language/Haskell/TH/Desugar/Expand.hs
@@ -271,7 +271,7 @@ dTypeToDPred (DVarT n)       = return $ DVarPr n
 dTypeToDPred (DConT n)       = return $ DConPr n
 dTypeToDPred DArrowT         = impossible "Arrow used as head of constraint"
 dTypeToDPred (DLitT _)       = impossible "Type literal used as head of constraint"
-dTypeToDPred (DWildCardT n)  = return (DWildCardPr n)
+dTypeToDPred DWildCardT      = return DWildCardPr
 
 -- | Expand all type synonyms and type families in the desugared abstract
 -- syntax tree provided, where type family simplification is on a "best effort"

--- a/Language/Haskell/TH/Desugar/Expand.hs
+++ b/Language/Haskell/TH/Desugar/Expand.hs
@@ -110,11 +110,7 @@ expand_con ign n args = do
         ty' <- expand_type ign ty
         return $ foldl DAppT ty' rest_args
 
-#if __GLASGOW_HASKELL__ > 710
-    DTyConI (DOpenTypeFamilyD _n tvbs _frs _ann) _
-#else
-    DTyConI (DFamilyD TypeFam _n tvbs _mkind) _
-#endif
+    DTyConI (DOpenTypeFamilyD (DTypeFamilyHead _n tvbs _frs _ann)) _
       |  length args >= length tvbs   -- this should always be true!
       ,  args_ok
       -> do
@@ -132,11 +128,8 @@ expand_con ign n args = do
             return $ foldl DAppT ty' rest_args
           _ -> return $ foldl DAppT (DConT n) args
 
-#if __GLASGOW_HASKELL__ > 710
-    DTyConI (DClosedTypeFamilyD _n tvbs _frs _ann eqns) _
-#else
-    DTyConI (DClosedTypeFamilyD _n tvbs _resk eqns) _
-#endif
+
+    DTyConI (DClosedTypeFamilyD (DTypeFamilyHead _n tvbs _frs _ann) eqns) _
       |  length args >= length tvbs
       ,  args_ok
       -> do
@@ -167,12 +160,8 @@ expand_con ign n args = do
       m_info <- dsReify con_name
       return $ case m_info of
         Nothing -> False   -- we don't know anything. False is safe.
-#if __GLASGOW_HASKELL__ > 710
         Just (DTyConI (DOpenTypeFamilyD {}) _)   -> False
         Just (DTyConI (DDataFamilyD {}) _)       -> False
-#else        
-        Just (DTyConI (DFamilyD {}) _)           -> False
-#endif
         Just (DTyConI (DClosedTypeFamilyD {}) _) -> False
         _                                        -> True
     no_tyvar_tyfam t = gmapQl (liftM2 (&&)) (return True) no_tyvars_tyfams t
@@ -272,6 +261,7 @@ dTypeToDPred (DConT n)       = return $ DConPr n
 dTypeToDPred DArrowT         = impossible "Arrow used as head of constraint"
 dTypeToDPred (DLitT _)       = impossible "Type literal used as head of constraint"
 dTypeToDPred DWildCardT      = return DWildCardPr
+dTypeToDPred DStarT          = impossible "Star used as head of constraint"
 
 -- | Expand all type synonyms and type families in the desugared abstract
 -- syntax tree provided, where type family simplification is on a "best effort"

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -23,14 +23,16 @@ import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Instances ()
 import Language.Haskell.TH.Lift
 
-$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DKind, ''DPred, ''DTyVarBndr
+$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DPred, ''DTyVarBndr
                  , ''DMatch, ''DClause, ''DLetDec, ''DDec, ''DCon
                  , ''DConFields, ''DForeign, ''DPragma, ''DRuleBndr, ''DTySynEqn
                  , ''NewOrData
 #if __GLASGOW_HASKELL__ < 707
                  , ''AnnTarget, ''Role
 #endif
-#if __GLASGOW_HASKELL__ > 710
-                 , ''DFamilyResultSig
+                 , ''DTypeFamilyHead,  ''DFamilyResultSig
+#if __GLASGOW_HASKELL__ <= 710
+                 , ''InjectivityAnn, ''Bang, ''SourceUnpackedness
+                 , ''SourceStrictness
 #endif
                  ])

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -308,13 +308,8 @@ mkDataConCase var case_alts = do
       Just (DTyConI tycon_dec _) <- dsReify ty_name
       return $ S.fromList $ map get_con_name $ get_cons tycon_dec
 
-#if MIN_VERSION_template_haskell(2,11,0)
-    get_cons (DDataD _ _ _ _ _ cons _)     = cons
-    get_cons (DDataInstD _ _ _ _ _ cons _) = cons
-#else
     get_cons (DDataD _ _ _ _ cons _)     = cons
     get_cons (DDataInstD _ _ _ _ cons _) = cons
-#endif
     get_cons _                           = []
 
     get_con_name (DCon _ _ n _) = n

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -308,8 +308,13 @@ mkDataConCase var case_alts = do
       Just (DTyConI tycon_dec _) <- dsReify ty_name
       return $ S.fromList $ map get_con_name $ get_cons tycon_dec
 
+#if MIN_VERSION_template_haskell(2,11,0)
+    get_cons (DDataD _ _ _ _ _ cons _)     = cons
+    get_cons (DDataInstD _ _ _ _ _ cons _) = cons
+#else
     get_cons (DDataD _ _ _ _ cons _)     = cons
     get_cons (DDataInstD _ _ _ _ cons _) = cons
+#endif
     get_cons _                           = []
 
     get_con_name (DCon _ _ n _) = n

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -136,7 +136,7 @@ decToTH (DDataInstD Newtype cxt n tys [con] derivings) =
 #endif
 #if __GLASGOW_HASKELL__ < 707
 decToTH (DTySynInstD n eqn) = [tySynEqnToTHDec n eqn]
-decToTH (DClosedTypeFamilyD (DTypeFamilyHead n tvbs frs) eqns) =
+decToTH (DClosedTypeFamilyD (DTypeFamilyHead n tvbs frs _ann) eqns) =
   (FamilyD TypeFam n (map tvbToTH tvbs) (frsToTH frs)) :
   (map (tySynEqnToTHDec n) eqns)
 decToTH (DRoleAnnotD {}) = []

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -54,7 +54,11 @@ $(dsDecSplice S.standalone_deriving_test)
 #endif
 
 $(do decs <- S.rec_sel_test
+#if MIN_VERSION_template_haskell(2,11,0)
+     [DDataD nd [] name [DPlainTV tvbName] mk cons []] <- dsDecs decs
+#else
      [DDataD nd [] name [DPlainTV tvbName] cons []] <- dsDecs decs
+#endif
      let arg_ty = (DConT name) `DAppT` (DVarT tvbName)
      recsels <- fmap concat $ mapM (getRecordSelectors arg_ty) cons
      let num_sels = length recsels `div` 2 -- ignore type sigs
@@ -68,6 +72,10 @@ $(do decs <- S.rec_sel_test
                fields' = zip stricts types
            in
            DCon tvbs cxt con_name (DNormalC fields')
+#if MIN_VERSION_template_haskell(2,11,0)
+         plaindata = [DDataD nd [] name [DPlainTV tvbName] mk (map unrecord cons) []]
+#else
          plaindata = [DDataD nd [] name [DPlainTV tvbName] (map unrecord cons) []]
+#endif
      return (decsToTH plaindata ++ map letDecToTH recsels))
 

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -54,11 +54,7 @@ $(dsDecSplice S.standalone_deriving_test)
 #endif
 
 $(do decs <- S.rec_sel_test
-#if MIN_VERSION_template_haskell(2,11,0)
-     [DDataD nd [] name [DPlainTV tvbName] mk cons []] <- dsDecs decs
-#else
      [DDataD nd [] name [DPlainTV tvbName] cons []] <- dsDecs decs
-#endif
      let arg_ty = (DConT name) `DAppT` (DVarT tvbName)
      recsels <- fmap concat $ mapM (getRecordSelectors arg_ty) cons
      let num_sels = length recsels `div` 2 -- ignore type sigs
@@ -67,15 +63,11 @@ $(do decs <- S.rec_sel_test
                   ++ "Wanted " ++ show S.rec_sel_test_num_sels
                   ++ ", Got " ++ show num_sels
      let unrecord c@(DCon _ _ _ (DNormalC {})) = c
-         unrecord (DCon tvbs cxt con_name (DRecC fields)) =
+         unrecord (DCon tvbs cxt con_name (DRecC fields rty)) =
            let (_names, stricts, types) = unzip3 fields
                fields' = zip stricts types
            in
-           DCon tvbs cxt con_name (DNormalC fields')
-#if MIN_VERSION_template_haskell(2,11,0)
-         plaindata = [DDataD nd [] name [DPlainTV tvbName] mk (map unrecord cons) []]
-#else
+           DCon tvbs cxt con_name (DNormalC fields' rty)
          plaindata = [DDataD nd [] name [DPlainTV tvbName] (map unrecord cons) []]
-#endif
      return (decsToTH plaindata ++ map letDecToTH recsels))
 

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -159,19 +159,14 @@ test_mkName = and [ hasSameType (Proxy :: Proxy FuzzSyn) (Proxy :: Proxy Fuzz)
 
 test_bug8884 :: Bool
 test_bug8884 = $(do info <- reify ''Poly
-#if __GLASGOW_HASKELL__ > 710
-                    dinfo@(DTyConI (DOpenTypeFamilyD _name _tvbs (DKindSig resK) _ann)
+                    dinfo@(DTyConI (DOpenTypeFamilyD (DTypeFamilyHead _name _tvbs (DKindSig resK) _ann))
                                    (Just [DTySynInstD _name2 (DTySynEqn lhs _rhs)]))
-#else
-                    dinfo@(DTyConI (DFamilyD TypeFam _name _tvbs (Just resK))
-                                   (Just [DTySynInstD _name2 (DTySynEqn lhs _rhs)]))
-#endif
                       <- dsInfo info
                     case (resK, lhs) of
 #if __GLASGOW_HASKELL__ < 709
-                      (DStarK, [DVarT _]) -> [| True |]
+                      (DStarT, [DVarT _]) -> [| True |]
 #else
-                      (DStarK, [DSigT (DVarT _) (DVarK _)]) -> [| True |]
+                      (DStarT, [DSigT (DVarT _) (DVarT _)]) -> [| True |]
 #endif
                       _                                     -> do
                         runIO $ do

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -274,7 +274,7 @@ dectest9 = [d| data family Dec9 a (b :: * -> *) :: * -> * |]
 ds_dectest10 = DClosedTypeFamilyD
                  (DTypeFamilyHead (mkName "Dec10")
                                   [DPlainTV (mkName "a")]
-                                  (DKindSig (DArrowT DStarT DStarT))
+                                  (DAppT (DAppT DArrowT DStarT) DStarT)
                                   Nothing)
                  [ DTySynEqn [DConT ''Int]  (DConT ''Maybe)
                  , DTySynEqn [DConT ''Bool] (DConT ''[]) ]

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -271,11 +271,13 @@ dectest7 = [d| type family Dec7 a (b :: *) (c :: Bool) :: * -> * |]
 dectest8 = [d| type family Dec8 a |]
 dectest9 = [d| data family Dec9 a (b :: * -> *) :: * -> * |]
 #if __GLASGOW_HASKELL__ < 707
-ds_dectest10 = DClosedTypeFamilyD (mkName "Dec10")
-                                 [DPlainTV (mkName "a")]
-                                 (Just (DArrowT DStarT DStarT))
-                                 [ DTySynEqn [DConT ''Int]  (DConT ''Maybe)
-                                 , DTySynEqn [DConT ''Bool] (DConT ''[]) ]
+ds_dectest10 = DClosedTypeFamilyD
+                 (DTypeFamilyHead (mkName "Dec10")
+                                  [DPlainTV (mkName "a")]
+                                  (DKindSig (DArrowT DStarT DStarT))
+                                  Nothing)
+                 [ DTySynEqn [DConT ''Int]  (DConT ''Maybe)
+                 , DTySynEqn [DConT ''Bool] (DConT ''[]) ]
 dectest10 = [d| type family Dec10 a :: * -> *
                 type instance Dec10 Int = Maybe
                 type instance Dec10 Bool = [] |]

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -272,10 +272,11 @@ dectest8 = [d| type family Dec8 a |]
 dectest9 = [d| data family Dec9 a (b :: * -> *) :: * -> * |]
 #if __GLASGOW_HASKELL__ < 707
 ds_dectest10 = DClosedTypeFamilyD
-                 (DTypeFamilyHead (mkName "Dec10")
-                                  [DPlainTV (mkName "a")]
-                                  (DAppT (DAppT DArrowT DStarT) DStarT)
-                                  Nothing)
+                 (DTypeFamilyHead
+                    (mkName "Dec10")
+                    [DPlainTV (mkName "a")]
+                    (DKindSig (DAppT (DAppT DArrowT DStarT) DStarT))
+                    Nothing)
                  [ DTySynEqn [DConT ''Int]  (DConT ''Maybe)
                  , DTySynEqn [DConT ''Bool] (DConT ''[]) ]
 dectest10 = [d| type family Dec10 a :: * -> *

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -79,10 +79,31 @@ eqTHSplice a b =
   then [| True |]
   else [| False |]
 
+-- Note [Annotating list elements]
+--
+-- Type annotations on list elements are needed to satisfy GHC 8.0-rc1, otherwise
+-- we get errors like:
+--
+--    Test/Run.hs:63:53: error:
+--        • Couldn't match type ‘Maybe Integer’ with ‘forall a. Maybe a’
+--          Expected type: [forall a. Maybe a]
+--            Actual type: [Maybe Integer]
+--        • In the second argument of ‘(:)’, namely
+--            ‘(:) (Just 19) ((:) (Nothing :: Maybe Integer) [])’
+--          In the second argument of ‘(:)’, namely
+--            ‘(:) Nothing ((:) (Just 19) ((:) (Nothing :: Maybe Integer) []))’
+--          In the second argument of ‘map’, namely
+--            ‘(:)
+--               (Just 1)
+--               ((:) Nothing ((:) (Just 19) ((:) (Nothing :: Maybe Integer) [])))’
+--
+-- This is probably a bug in the GHC type checker, but I haven't been able to
+-- reduce it yet
 
 test1_sections = [| map ((* 3) . (4 +) . (\x -> x * x)) [10, 11, 12] |]
 test2_lampats = [| (\(Just x) (Left z) -> x + z) (Just 5) (Left 10) |]
-test3_lamcase = [| foldr (-) 0 (map (\case { Just x -> x ; Nothing -> (-3) }) [Just 1, Nothing, Just 19, Nothing]) |]
+-- See Note [Annotating list elements]
+test3_lamcase = [| foldr (-) 0 (map (\case { Just x -> x ; Nothing -> (-3) }) [Just 1, Nothing :: Maybe Integer, Just 19, Nothing :: Maybe Integer]) |]
 test4_tuples = [| (\(a, _) (# b, _ #) -> a + b) (1,2) (# 3, 4 #) |]
 test5_ifs = [| if (5 > 7) then "foo" else if | Nothing <- Just "bar", True -> "blargh" | otherwise -> "bum" |]
 test6_ifs2 = [| if | Nothing <- Nothing, False -> 3 | Just _ <- Just "foo" -> 5 |]
@@ -116,7 +137,8 @@ data InfixType = Int :+: Bool
   deriving (Show, Eq)
 
 test17_infixp = [| map (\(x :+: y) -> if y then x + 1 else x - 1) [5 :+: True, 10 :+: False] |]
-test18_tildep = [| map (\ ~() -> Nothing :: Maybe Int) [undefined, ()] |]
+-- See Note [Annotating list elements]
+test18_tildep = [| map (\ ~() -> Nothing :: Maybe Int) [undefined :: (), ()] |]
 test19_bangp = [| map (\ !() -> 5) [()] |]
 test20_asp = [| map (\ a@(b :+: c) -> (if c then b + 1 else b - 1, a)) [5 :+: True, 10 :+: False] |]
 test21_wildp = [| zipWith (\_ _ -> 10) [1,2,3] ['a','b','c'] |]
@@ -124,16 +146,19 @@ test22_listp = [| map (\ [a,b,c] -> a + b + c) [[1,2,3],[4,5,6]] |]
 -- type signatures in patterns not yet handled by Template Haskell
 -- test23_sigp = [| map (\ (a :: Int) -> a + a) [5, 10] |]
 
-test24_fun = [| let f (Just x) = x
+-- See Note [Annotating list elements]
+test24_fun = [| let f :: Maybe (Maybe a) -> Maybe a
+                    f (Just x) = x
                     f Nothing = Nothing in
                 f (Just (Just 10)) |]
 
+-- See Note [Annotating list elements]
 test25_fun2 = [| let f (Just x)
                        | x > 0 = x
                        | x < 0 = x + 10
                      f Nothing = 0
                      f _ = 18 in
-                 map f [Just (-5), Just 5, Just 10, Nothing, Just 0] |]
+                 map f [Just (-5), Just 5, Just 10, Nothing :: Maybe Integer, Just 0] |]
 
 test26_forall = [| let f :: Num a => a -> a
                        f x = x + 10 in

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -273,7 +273,7 @@ dectest9 = [d| data family Dec9 a (b :: * -> *) :: * -> * |]
 #if __GLASGOW_HASKELL__ < 707
 ds_dectest10 = DClosedTypeFamilyD (mkName "Dec10")
                                  [DPlainTV (mkName "a")]
-                                 (Just (DArrowK DStarK DStarK))
+                                 (Just (DArrowT DStarT DStarT))
                                  [ DTySynEqn [DConT ''Int]  (DConT ''Maybe)
                                  , DTySynEqn [DConT ''Bool] (DConT ''[]) ]
 dectest10 = [d| type family Dec10 a :: * -> *

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -1,5 +1,5 @@
 name:           th-desugar
-version:        1.5.5
+version:        1.6
 cabal-version:  >= 1.10
 synopsis:       Functions to desugar Template Haskell
 homepage:       http://www.cis.upenn.edu/~eir/packages/th-desugar
@@ -26,7 +26,7 @@ description:
 source-repository this
   type:     git
   location: https://github.com/goldfirere/th-desugar.git
-  tag:      v1.5.5
+  tag:      v1.6
 
 library
   build-depends:
@@ -36,7 +36,8 @@ library
       mtl >= 2.1,
       syb >= 0.4,
       th-lift >= 0.6.1,
-      th-orphans >= 0.9.1
+      th-orphans >= 0.9.1,
+      th-expand-syns >= 0.3.0.6
   default-extensions: TemplateHaskell
   exposed-modules:    Language.Haskell.TH.Desugar,
                       Language.Haskell.TH.Desugar.Sweeten,
@@ -69,4 +70,5 @@ test-suite spec
       hspec >= 1.3,
       th-desugar,
       th-lift >= 0.6.1,
-      th-orphans >= 0.9.1
+      th-orphans >= 0.9.1,
+      th-expand-syns >= 0.3.0.6


### PR DESCRIPTION
Currently has the following test-suite failures on GHC 8.0.1-rc1:

      Test/Run.hs:275:
      1) th-desugar library reifies local definition 2

      Test/Run.hs:275:
      2) th-desugar library reifies local definition 3

Basically, this is due to how GHC is now treating implicitly bound type variables differently it seems. Given:

```haskell
  class R2 a b where
    r3 :: a -> b -> c -> a
    type R4 b a :: *
    data R5 a :: *
```

reifying `r3`  in GHC-7.10.3 will give something along the lines of:

```haskell
r3 :: forall a b . R2 a b => forall c . a -> b -> c -> a
```

and `th-desugar` would give the same info.

However, in GHC 8-rc1, reifying `r3` gives something along the lines of:

```haskell
r3 :: forall a b . R2 a b => a -> b -> c -> a
```

where `th-desugar` still gives:

```haskell
r3 :: forall a b . R2 a b => forall c . a -> b -> c -> a
```

That is the testsuite failure you are seeing. If you have any hints where to look for a solution, I'm happy to investigate. I'm sending this pull request nonetheless just to let you know that I've already done some work on porting `th-desugar` over to GHC 8.0-rc1.

The branch can be build and tested with the following `stack.yaml`: https://gist.github.com/christiaanb/2c94f162c706fca7ee76

Another weird thing is that I needed to annotate some TH quotes with their types, for example, the original:

```haskell
test3_lamcase = [| foldr (-) 0 (map (\case { Just x -> x ; Nothing -> (-3) }) [Just 1, Nothing, Just 19, Nothing]) |]
```

gives the following error:

```
   Test/Run.hs:63:53: error:
       • Couldn't match type ‘Maybe Integer’ with ‘forall a. Maybe a’
         Expected type: [forall a. Maybe a]
           Actual type: [Maybe Integer]
       • In the second argument of ‘(:)’, namely
           ‘(:) (Just 19) ((:) (Nothing :: Maybe Integer) [])’
         In the second argument of ‘(:)’, namely
           ‘(:) Nothing ((:) (Just 19) ((:) (Nothing :: Maybe Integer) []))’
         In the second argument of ‘map’, namely
           ‘(:)
              (Just 1)
              ((:) Nothing ((:) (Just 19) ((:) (Nothing :: Maybe Integer) [])))’
```

I had to annotate it like so:

```haskell
test3_lamcase = [| foldr (-) 0 (map (\case { Just x -> x ; Nothing -> (-3) }) [Just 1, Nothing :: Maybe Integer, Just 19, Nothing :: Maybe Integer]) |]
```

in order for it to succesfully compile. I haven't been able to reduce it to a small test-case yet.