### PR TITLE
Adapt to template-haskell changes in GHC HEAD deriving strategies.

### DIFF
--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -9,6 +9,7 @@ processing. The desugared types and constructors are prefixed with a D.
 
 {-# LANGUAGE TemplateHaskell, LambdaCase, CPP, DeriveDataTypeable,
              DeriveGeneric, TupleSections #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-imports #-}
 
 module Language.Haskell.TH.Desugar.Core where
 

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -14,8 +14,8 @@ module Language.Haskell.TH.Desugar.Core where
 
 import Prelude hiding (mapM, foldl, foldr, all, elem, exp, concatMap, and)
 
-import Language.Haskell.TH hiding (match, clause, cxt)
-import Language.Haskell.TH.Syntax hiding (lift)
+import Language.Haskell.TH hiding (Newtype, match, clause, cxt)
+import Language.Haskell.TH.Syntax hiding (Newtype, lift)
 import Language.Haskell.TH.ExpandSyns ( expandSyns )
 
 #if __GLASGOW_HASKELL__ < 709
@@ -231,6 +231,10 @@ data DInfo = DTyConI DDec (Maybe [DInstanceDec])
            deriving (Show, Typeable, Data, Generic)
 
 type DInstanceDec = DDec -- ^ Guaranteed to be an instance declaration
+
+#if __GLASGOW_HASKELL__ >= 801
+data DDerivClause = DDerivClause (Maybe DerivStrategy) DCxt
+#endif
 
 -- | Desugar an expression
 dsExp :: DsMonad q => Exp -> q DExp
@@ -707,12 +711,12 @@ dsDec (DataD cxt n tvbs mk cons derivings) = do
   (:[]) <$> (DDataD Data <$> dsCxt cxt <*> pure n
                          <*> ((++ extra_tvbs) <$> mapM dsTvb tvbs)
                          <*> concatMapM dsCon cons
-                         <*> dsCxt derivings)
+                         <*> concatMapM dsDerivClause derivings)
 dsDec (NewtypeD cxt n tvbs mk con derivings) = do
   extra_tvbs <- mkExtraTvbs tvbs mk
   (:[]) <$> (DDataD Newtype <$> dsCxt cxt <*> pure n
                             <*> ((++ extra_tvbs) <$> mapM dsTvb tvbs)
-                            <*> dsCon con <*> dsCxt derivings)
+                            <*> dsCon con <*> concatMapM dsDerivClause derivings)
 #else
 dsDec (DataD cxt n tvbs cons derivings) =
   (:[]) <$> (DDataD Data <$> dsCxt cxt <*> pure n
@@ -758,13 +762,13 @@ dsDec (DataInstD cxt n tys mk cons derivings) = do
   (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n
                              <*> ((++ extra_tvbs) <$> mapM dsType tys)
                              <*> concatMapM dsCon cons
-                             <*> dsCxt derivings)
+                             <*> concatMapM dsDerivClause derivings)
 dsDec (NewtypeInstD cxt n tys mk con derivings) = do
   extra_tvbs <- map dTyVarBndrToDType <$> mkExtraTvbs [] mk
   (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n
                                 <*> ((++ extra_tvbs) <$> mapM dsType tys)
                                 <*> dsCon con
-                                <*> dsCxt derivings)
+                                <*> concatMapM dsDerivClause derivings)
 #else
 dsDec (DataInstD cxt n tys cons derivings) = do
   (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n <*> mapM dsType tys
@@ -792,8 +796,14 @@ dsDec (ClosedTypeFamilyD n tvbs m_k eqns) = do
 dsDec (RoleAnnotD n roles) = return [DRoleAnnotD n roles]
 #endif
 #if __GLASGOW_HASKELL__ >= 709
-dsDec (StandaloneDerivD cxt ty) = (:[]) <$> (DStandaloneDerivD <$> dsCxt cxt
-                                                               <*> dsType ty)
+#if __GLASGOW_HASKELL__ >= 801
+dsDec (StandaloneDerivD (Just _) cxt ty) = fail "Deriving strategies not supported by th-desugar."
+dsDec (StandaloneDerivD Nothing cxt ty) =
+#else
+dsDec (StandaloneDerivD cxt ty) =
+#endif
+  (:[]) <$> (DStandaloneDerivD <$> dsCxt cxt
+                               <*> dsType ty)
 dsDec (DefaultSigD n ty) = (:[]) <$> (DDefaultSigD n <$> dsType ty)
 #endif
 
@@ -1031,6 +1041,15 @@ dsTvb (KindedTV n k) = DKindedTV n <$> dsType k
 -- | Desugar a @Cxt@
 dsCxt :: DsMonad q => Cxt -> q DCxt
 dsCxt = concatMapM dsPred
+
+#if __GLASGOW_HASKELL__ >= 801
+dsDerivClause :: DsMonad q => DerivClause -> q DCxt
+dsDerivClause (DerivClause Nothing cxt) = dsCxt cxt
+dsDerivClause (DerivClause _ cxt) = fail "Deriving strategies not supported in th-desugar."
+#else
+dsDerivClause :: DsMonad q => Pred -> q DCxt
+dsDerivClause = dsPred
+#endif
 
 -- | Desugar a @Pred@, flattening any internal tuples
 dsPred :: DsMonad q => Pred -> q DCxt

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -8,6 +8,7 @@ Converts desugared TH back into real TH.
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-imports #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -34,7 +34,7 @@ module Language.Haskell.TH.Desugar.Sweeten (
 import Prelude hiding (exp)
 import Control.Arrow
 
-import Language.Haskell.TH hiding (cxt)
+import Language.Haskell.TH hiding (Newtype, cxt)
 
 import Language.Haskell.TH.Desugar.Core
 import Language.Haskell.TH.Desugar.Util
@@ -77,7 +77,11 @@ decToTH (DLetDec d) = [letDecToTH d]
 decToTH (DDataD Data cxt n tvbs cons derivings) =
 #if __GLASGOW_HASKELL__ > 710
   [DataD (cxtToTH cxt) n (map tvbToTH tvbs) Nothing (map conToTH cons)
+#if __GLASGOW_HASKELL__ >= 801
+         [DerivClause Nothing (cxtToTH derivings)]]
+#else
          (cxtToTH derivings)]
+#endif
 #else
   [DataD (cxtToTH cxt) n (map tvbToTH tvbs) (map conToTH cons)
          (map derivingToTH derivings)]
@@ -85,7 +89,11 @@ decToTH (DDataD Data cxt n tvbs cons derivings) =
 decToTH (DDataD Newtype cxt n tvbs [con] derivings) =
 #if __GLASGOW_HASKELL__ > 710
   [NewtypeD (cxtToTH cxt) n (map tvbToTH tvbs) Nothing (conToTH con)
+#if __GLASGOW_HASKELL__ >= 801
+            [DerivClause Nothing (cxtToTH derivings)]]
+#else
             (cxtToTH derivings)]
+#endif
 #else
   [NewtypeD (cxtToTH cxt) n (map tvbToTH tvbs) (conToTH con)
             (map derivingToTH derivings)]
@@ -118,7 +126,11 @@ decToTH (DDataFamilyD n tvbs) =
 decToTH (DDataInstD Data cxt n tys cons derivings) =
 #if __GLASGOW_HASKELL__ > 710
   [DataInstD (cxtToTH cxt) n (map typeToTH tys) Nothing (map conToTH cons)
+#if __GLASGOW_HASKELL__ >= 801
+             [DerivClause Nothing (cxtToTH derivings)]
+#else
              (cxtToTH derivings)
+#endif
   ]
 #else
   [DataInstD (cxtToTH cxt) n (map typeToTH tys) (map conToTH cons)
@@ -128,7 +140,11 @@ decToTH (DDataInstD Data cxt n tys cons derivings) =
 decToTH (DDataInstD Newtype cxt n tys [con] derivings) =
 #if __GLASGOW_HASKELL__ > 710
   [NewtypeInstD (cxtToTH cxt) n (map typeToTH tys) Nothing (conToTH con)
+#if __GLASGOW_HASKELL__ >= 801
+                [DerivClause Nothing (cxtToTH derivings)]
+#else
                 (cxtToTH derivings)
+#endif
   ]
 #else
   [NewtypeInstD (cxtToTH cxt) n (map typeToTH tys) (conToTH con)
@@ -161,7 +177,11 @@ decToTH (DDefaultSigD {})      =
   error "Default method signatures supported only in GHC 7.10+"
 #else
 decToTH (DStandaloneDerivD cxt ty) =
+#if __GLASGOW_HASKELL__ >= 801
+  [StandaloneDerivD Nothing (cxtToTH cxt) (typeToTH ty)]
+#else
   [StandaloneDerivD (cxtToTH cxt) (typeToTH ty)]
+#endif
 decToTH (DDefaultSigD n ty)        = [DefaultSigD n (typeToTH ty)]
 #endif
 decToTH _ = error "Newtype declaration without exactly 1 constructor."


### PR DESCRIPTION
This patch does not add support for them in th-desugar. But it doesn't
make the situation any worse either. At least with this patch
th-desugar now compiles, and TH code that doesn't mention strategies
gets desugared the same as before.

cc @RyanGIScott