### PR TITLE
Add support for type signatures in patterns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ env:
  - CABALVER=1.22 GHCVER=7.10.2
  - CABALVER=1.22 GHCVER=7.10.3
  - CABALVER=1.24 GHCVER=8.0.1
-# HEAD has TH updates - CABALVER=1.24 GHCVER=head   # see section about GHC HEAD snapshots
+ - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+
+allow_failures:
+ - env: CABALVER=head GHCVER=head
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ env:
  - CABALVER=1.24 GHCVER=8.0.1
  - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
-allow_failures:
- - env: CABALVER=head GHCVER=head
+matrix:
+  allow_failures:
+   - env: CABALVER=head GHCVER=head
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -160,6 +160,7 @@ flattenDValD (DValD pat exp) = do
         DConPa con ps -> DConPa con (map (wildify name y) ps)
         DTildePa pa -> DTildePa (wildify name y pa)
         DBangPa pa -> DBangPa (wildify name y pa)
+        DSigPa pa ty -> DSigPa (wildify name y pa) ty
         DWildPa -> DWildPa
 
 flattenDValD other_dec = return [other_dec]

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -622,6 +622,7 @@ extractBoundNamesDPat (DVarPa n)      = S.singleton n
 extractBoundNamesDPat (DConPa _ pats) = S.unions (map extractBoundNamesDPat pats)
 extractBoundNamesDPat (DTildePa p)    = extractBoundNamesDPat p
 extractBoundNamesDPat (DBangPa p)     = extractBoundNamesDPat p
+extractBoundNamesDPat (DSigPa p _)    = extractBoundNamesDPat p
 extractBoundNamesDPat DWildPa         = S.empty
 
 -- | Desugar @Info@

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -142,7 +142,9 @@ tidy1 v (DBangPa pat) =
     DConPa _ _ -> tidy1 v pat   -- already strict
     DTildePa p -> tidy1 v (DBangPa p) -- discard ~ under !
     DBangPa p  -> tidy1 v (DBangPa p) -- discard ! under !
+    DSigPa p _ -> tidy1 v (DBangPa p) -- discard sig under !
     DWildPa    -> return (id, DBangPa pat)  -- no change
+tidy1 v (DSigPa pat _) = tidy1 v pat
 tidy1 _ DWildPa = return (id, DWildPa)
 
 wrapBind :: Name -> Name -> DExp -> DExp
@@ -216,10 +218,11 @@ groupClauses clauses
 
 patGroup :: DPat -> PatGroup
 patGroup (DLitPa l)     = PgLit l
-patGroup (DVarPa {})    = error "Internal error in th-desugar (patGroup DVarP)"
+patGroup (DVarPa {})    = error "Internal error in th-desugar (patGroup DVarPa)"
 patGroup (DConPa con _) = PgCon con
-patGroup (DTildePa {})  = error "Internal error in th-desugar (patGroup DTildeP)"
+patGroup (DTildePa {})  = error "Internal error in th-desugar (patGroup DTildePa)"
 patGroup (DBangPa {})   = PgBang
+patGroup (DSigPa{})     = error "Internal error in th-desugar (patGroup DSigPa)"
 patGroup DWildPa        = PgAny
 
 sameGroup :: PatGroup -> PatGroup -> Bool

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -73,6 +73,7 @@ patToTH (DVarPa n)      = VarP n
 patToTH (DConPa n pats) = ConP n (map patToTH pats)
 patToTH (DTildePa pat)  = TildeP (patToTH pat)
 patToTH (DBangPa pat)   = BangP (patToTH pat)
+patToTH (DSigPa pat ty) = SigP (patToTH pat) (typeToTH ty)
 patToTH DWildPa         = WildP
 
 decsToTH :: [DDec] -> [Dec]

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -112,7 +112,8 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
              , "wildcard" ~: $test40_wildcards@=? $(dsSplice test40_wildcards)
 #endif
 #if __GLASGOW_HASKELL__ >= 801
-             , "typeapps" ~: $test41_typeapps @=? $(dsSplice test41_typeapps)
+             , "typeapps"   ~: $test41_typeapps   @=? $(dsSplice test41_typeapps)
+             , "scoped_tvs" ~: $test42_scoped_tvs @=? $(dsSplice test42_scoped_tvs)
 #endif
              ]
 

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -89,8 +89,9 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
              , "asp"      ~: $test20_asp      @=? $(dsSplice test20_asp)
              , "wildp"    ~: $test21_wildp    @=? $(dsSplice test21_wildp)
              , "listp"    ~: $test22_listp    @=? $(dsSplice test22_listp)
--- type signatures in patterns not yet handled by Template Haskell
---           , "sigp"     ~: $test23_sigp     @=? $(dsSplice test23_sigp)
+#if __GLASGOW_HASKELL__ >= 801
+             , "sigp"     ~: $test23_sigp     @=? $(dsSplice test23_sigp)
+#endif
              , "fun"      ~: $test24_fun      @=? $(dsSplice test24_fun)
              , "fun2"     ~: $test25_fun2     @=? $(dsSplice test25_fun2)
              , "forall"   ~: $test26_forall   @=? $(dsSplice test26_forall)

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -132,9 +132,11 @@ test_e6b = $(test_expand6 >>= dsExp >>= expand >>= return . expToTH)
 test_e7a = $test_expand7
 test_e7b = $(test_expand7 >>= dsExp >>= expand >>= return . expToTH)
 test_e7c = $(test_expand7 >>= dsExp >>= expandUnsoundly >>= return . expToTH)
+#if __GLASGOW_HASKELL__ < 801
 test_e8a = $(test_expand8 >>= dsExp >>= expand >>= return . expToTH)
-  -- the line above should fail once GHC#8953 is fixed for closed type
-  -- families
+  -- This won't expand on recent GHCs now that GHC Trac #8953 is fixed for
+  -- closed type families.
+#endif
 test_e8b = $(test_expand8 >>= dsExp >>= expandUnsoundly >>= return . expToTH)
 #endif
 
@@ -151,7 +153,9 @@ test_expand = and [ hasSameType test35a test35b
                   , hasSameType test_e6a test_e6b
                   , hasSameType test_e7a test_e7b
                   , hasSameType test_e7a test_e7c
+#if __GLASGOW_HASKELL__ < 801
                   , hasSameType test_e8a test_e8a
+#endif
 #endif
                   ]
 

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -222,10 +222,9 @@ test41_typeapps = [| let f :: forall a. (a -> Bool) -> Bool
                          f g = g (undefined @_ @a) in
                      f (const True) |]
 
-test42_scoped_tvs = [| let f :: forall a. Maybe a -> Bool
-                           f (Just (_ :: a)) = True
-                           f Nothing         = False
-                       in f Nothing |]
+test42_scoped_tvs = [| let f :: (Read a, Show a) => a -> String -> String
+                           f (_ :: b) x = show (read x :: b)
+                       in f True "True" |]
 #endif
 
 type family TFExpand x

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -154,8 +154,9 @@ test19_bangp = [| map (\ !() -> 5) [()] |]
 test20_asp = [| map (\ a@(b :+: c) -> (if c then b + 1 else b - 1, a)) [5 :+: True, 10 :+: False] |]
 test21_wildp = [| zipWith (\_ _ -> 10) [1,2,3] ['a','b','c'] |]
 test22_listp = [| map (\ [a,b,c] -> a + b + c) [[1,2,3],[4,5,6]] |]
--- type signatures in patterns not yet handled by Template Haskell
--- test23_sigp = [| map (\ (a :: Int) -> a + a) [5, 10] |]
+#if __GLASGOW_HASKELL__ >= 801
+test23_sigp = [| map (\ (a :: Int) -> a + a) [5, 10] |]
+#endif
 
 -- See Note [Annotating list elements]
 test24_fun = [| let f :: Maybe (Maybe a) -> Maybe a
@@ -481,6 +482,9 @@ test_exprs = [ test1_sections
              , test20_asp
              , test21_wildp
              , test22_listp
+#if __GLASGOW_HASKELL__ >= 801
+             , test23_sigp
+#endif
              , test24_fun
              , test25_fun2
              , test26_forall

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -422,7 +422,14 @@ reifyDecs = [d|
 
   type R20 = Bool
 #if __GLASGOW_HASKELL__ >= 707
-  type family R21 (a :: k) (b :: k) :: k where R21 (a :: k) (b :: k) = b
+  type family R21 (a :: k) (b :: k) :: k where
+#if __GLASGOW_HASKELL__ >= 801
+    R21 (a :: k) (b :: k) = b
+#else
+    -- Due to GHC Trac #12646, R21 will get reified without kind signatures on
+    -- a and b on older GHCs, so we must reflect that here.
+    R21 a b = b
+#endif
 #endif
   class XXX a where
     r22 :: a -> a

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -452,6 +452,9 @@ simplCaseTests =
      |]
   , [| let foo [] = True
            foo _  = False in (foo [], foo "hi") |]
+#if __GLASGOW_HASKELL__ >= 801
+  , test42_scoped_tvs
+#endif
   ]
 
 -- These foralls are needed because of bug trac9262, fixed in ghc-7.10.

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -422,7 +422,7 @@ reifyDecs = [d|
 
   type R20 = Bool
 #if __GLASGOW_HASKELL__ >= 707
-  type family R21 (a :: k) (b :: k) :: k where R21 a b = b
+  type family R21 (a :: k) (b :: k) :: k where R21 (a :: k) (b :: k) = b
 #endif
   class XXX a where
     r22 :: a -> a

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -223,7 +223,7 @@ test41_typeapps = [| let f :: forall a. (a -> Bool) -> Bool
                      f (const True) |]
 
 test42_scoped_tvs = [| let f :: (Read a, Show a) => a -> String -> String
-                           f (_ :: b) x = show (read x :: b)
+                           f (_ :: b) (x :: String) = show (read x :: b)
                        in f True "True" |]
 #endif
 
@@ -460,7 +460,9 @@ simplCaseTests =
   , [| let foo [] = True
            foo _  = False in (foo [], foo "hi") |]
 #if __GLASGOW_HASKELL__ >= 801
-  , test42_scoped_tvs
+  , [| let foo ([] :: String) = True
+           foo (_  :: String) = False
+        in foo "hello" |]
 #endif
   ]
 

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -221,6 +221,11 @@ test40_wildcards = [| let f :: (Show a, _) => a -> a -> _
 test41_typeapps = [| let f :: forall a. (a -> Bool) -> Bool
                          f g = g (undefined @_ @a) in
                      f (const True) |]
+
+test42_scoped_tvs = [| let f :: forall a. Maybe a -> Bool
+                           f (Just (_ :: a)) = True
+                           f Nothing         = False
+                       in f Nothing |]
 #endif
 
 type family TFExpand x
@@ -503,5 +508,6 @@ test_exprs = [ test1_sections
 #endif
 #if __GLASGOW_HASKELL__ >= 801
              , test41_typeapps
+             , test42_scoped_tvs
 #endif
              ]


### PR DESCRIPTION
In http://git.haskell.org/ghc.git/commit/b0121209f8fb47a7cb8fc32e10d8e2c06d4502c2, Template Haskell gained the ability to support type signatures in patterns. We should do the same in `th-desugar`.