### PR TITLE
Consolidate duplicate definitions of extractBoundNamesDPat

### DIFF
--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -164,14 +164,6 @@ flattenDValD (DValD pat exp) = do
 
 flattenDValD other_dec = return [other_dec]
 
-extractBoundNamesDPat :: DPat -> S.Set Name
-extractBoundNamesDPat (DLitPa _)      = S.empty
-extractBoundNamesDPat (DVarPa n)      = S.singleton n
-extractBoundNamesDPat (DConPa _ pats) = foldMap extractBoundNamesDPat pats
-extractBoundNamesDPat (DTildePa pat)  = extractBoundNamesDPat pat
-extractBoundNamesDPat (DBangPa pat)   = extractBoundNamesDPat pat
-extractBoundNamesDPat DWildPa         = S.empty
-
 fvDType :: DType -> S.Set Name
 fvDType = go
   where

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -616,6 +616,14 @@ removeWilds (DTildePa pat) = DTildePa <$> removeWilds pat
 removeWilds (DBangPa pat) = DBangPa <$> removeWilds pat
 removeWilds DWildPa = DVarPa <$> newUniqueName "wild"
 
+extractBoundNamesDPat :: DPat -> S.Set Name
+extractBoundNamesDPat (DLitPa _)      = S.empty
+extractBoundNamesDPat (DVarPa n)      = S.singleton n
+extractBoundNamesDPat (DConPa _ pats) = S.unions (map extractBoundNamesDPat pats)
+extractBoundNamesDPat (DTildePa p)    = extractBoundNamesDPat p
+extractBoundNamesDPat (DBangPa p)     = extractBoundNamesDPat p
+extractBoundNamesDPat DWildPa         = S.empty
+
 -- | Desugar @Info@
 dsInfo :: DsMonad q => Info -> q DInfo
 dsInfo (ClassI dec instances) = do

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -200,14 +200,6 @@ mkSelectorDecs pat name
       rhs_mr <- simplCase [scrut_var] [EquationInfo [pat] (\_ -> DVarE bndr_var)]
       return (DValD (DVarPa bndr_var) (rhs_mr (DVarE err_var)))
 
-extractBoundNamesDPat :: DPat -> S.Set Name
-extractBoundNamesDPat (DLitPa _)      = S.empty
-extractBoundNamesDPat (DVarPa n)      = S.singleton n
-extractBoundNamesDPat (DConPa _ pats) = S.unions (map extractBoundNamesDPat pats)
-extractBoundNamesDPat (DTildePa p)    = extractBoundNamesDPat p
-extractBoundNamesDPat (DBangPa p)     = extractBoundNamesDPat p
-extractBoundNamesDPat DWildPa         = S.empty
-
 data PatGroup
   = PgAny         -- immediate match (wilds, vars, lazies)
   | PgCon Name


### PR DESCRIPTION
Currently, `extractBoundNamesDPat` is defined in two different places (but with the same implementation). This PR moves `extractBoundNamesDPat` to `Language.Haskell.TH.Desugar.Core` so that it lives in a central location.