### PR TITLE
Fix error on pragmas in 'let'-declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
 
   allow_failures:
     - env: CABALVER=head GHCVER=head
+    - env: CABALVER=1.22 GHCVER=7.10.1
+    # https://github.com/ndmitchell/safe/issues/20#issuecomment-278955186
 
 before_install:
  - unset CC

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -69,7 +69,11 @@ scLetDec (DFunD name clauses@(DClause pats1 _ : _)) = do
   where
     sc_clause_rhs (DClause pats exp) = DClause pats <$> scExp exp
 scLetDec (DValD pat exp) = DValD pat <$> scExp exp
+scLetDec (DPragmaD prag) = DPragmaD <$> scLetPragma prag
 scLetDec dec = return dec
+
+scLetPragma :: DsMonad q => DPragma -> q DPragma
+scLetPragma = topEverywhereM scExp -- Only topEverywhereM because scExp already recurses on its own
 
 type MatchResult = DExp -> DExp
 

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -57,7 +57,10 @@ scExp (DCaseE scrut matches)
 scExp (DLetE decs body) = DLetE <$> mapM scLetDec decs <*> scExp body
 scExp (DSigE exp ty) = DSigE <$> scExp exp <*> pure ty
 scExp (DAppTypeE exp ty) = DAppTypeE <$> scExp exp <*> pure ty
-scExp e = return e
+scExp e@(DVarE {}) = return e
+scExp e@(DConE {}) = return e
+scExp e@(DLitE {}) = return e
+scExp e@(DStaticE {}) = return e
 
 -- | Like 'scExp', but for a 'DLetDec'.
 scLetDec :: DsMonad q => DLetDec -> q DLetDec
@@ -70,7 +73,9 @@ scLetDec (DFunD name clauses@(DClause pats1 _ : _)) = do
     sc_clause_rhs (DClause pats exp) = DClause pats <$> scExp exp
 scLetDec (DValD pat exp) = DValD pat <$> scExp exp
 scLetDec (DPragmaD prag) = DPragmaD <$> scLetPragma prag
-scLetDec dec = return dec
+scLetDec dec@(DSigD {}) = return dec
+scLetDec dec@(DInfixD {}) = return dec
+scLetDec dec@(DFunD _ []) = return dec
 
 scLetPragma :: DsMonad q => DPragma -> q DPragma
 scLetPragma = topEverywhereM scExp -- Only topEverywhereM because scExp already recurses on its own

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -51,10 +51,7 @@ expToTH (DLitE l)            = LitE l
 expToTH (DAppE e1 e2)        = AppE (expToTH e1) (expToTH e2)
 expToTH (DLamE names exp)    = LamE (map VarP names) (expToTH exp)
 expToTH (DCaseE exp matches) = CaseE (expToTH exp) (map matchToTH matches)
-expToTH (DLetE decs exp)     = case mapMaybe letDecToTH decs of
-                                  -- This can only happen if we somehow have a DLetE containing only pragmas
-                                  [] -> expToTH exp
-                                  decs' -> LetE decs' (expToTH exp)
+expToTH (DLetE decs exp)     = LetE (mapMaybe letDecToTH decs) (expToTH exp)
 expToTH (DSigE exp ty)       = SigE (expToTH exp) (typeToTH ty)
 #if __GLASGOW_HASKELL__ < 709
 expToTH (DStaticE _)         = error "Static expressions supported only in GHC 7.10+"

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -32,6 +32,7 @@ import Language.Haskell.TH  ( reportError )
 import Language.Haskell.TH.Desugar
 
 import Control.Monad
+import Data.Maybe( mapMaybe )
 
 $(dsDecSplice S.dectest1)
 $(dsDecSplice S.dectest2)
@@ -84,4 +85,4 @@ $(do decs <- S.rec_sel_test
            in
            DCon tvbs cxt con_name (DNormalC fields') rty
          plaindata = [DDataD nd [] name [DPlainTV tvbName] (map unrecord cons) []]
-     return (decsToTH plaindata ++ map letDecToTH recsels))
+     return (decsToTH plaindata ++ mapMaybe letDecToTH recsels))

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -238,6 +238,12 @@ test43_ubx_sums = [| let f :: (# Bool | String #) -> Bool
                      f (# | "a" #) |]
 #endif
 
+test44_let_pragma = [| let x :: Int
+                           x = 1
+                           {-# INLINE x #-}
+                       in x |]
+
+
 type family TFExpand x
 type instance TFExpand Int = Bool
 type instance TFExpand (Maybe a) = [a]
@@ -571,4 +577,5 @@ test_exprs = [ test1_sections
              , test42_scoped_tvs
              , test43_ubx_sums
 #endif
+             , test44_let_pragma
              ]


### PR DESCRIPTION
Hello,

this currently throws an error:
```haskell
test44_let_pragma = [| let x :: Int
                           x = 1
                           {-# INLINE x #-}
                       in x |]
```
I fixed it by moving `DPragmaD` into `DLetDec`. Not sure how much of an issue backwards compatibility is for this package; maybe `DPragmaD` could be made a pattern synonym and the real constructor in `DLetDec` could be named differently.

Another unfortunate breaking change is that `letDecToTH` has to return a `Maybe` now due to the possibility of unsupported pragmas.

Not sure about recursing into pragmas in `scLetDec` (`DExp`s in rules and annotations), but I did so since `scLetExp` mentions a "guarantee".