### PR TITLE
Fix getRecordSelectors at the source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@ Version 1.7
 
 * Support for `COMPLETE` pragmas.
 
+* `getRecordSelectors` now requires a list of `DCon`s as an argument. This
+  makes it easier to return correct record selector bindings in the event that
+  a record selector appears in multiple constructors. (See
+  [goldfirere/singletons#180](https://github.com/goldfirere/singletons/issues/180)
+  for an example of where the old behavior of `getRecordSelectors` went wrong.)
+
 Version 1.6
 -----------
 * Work with GHC 8, with thanks to @christiaanb for getting this change going.

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -271,13 +271,13 @@ getRecordSelectors arg_ty cons = merge_let_decs `fmap` concatMapM get_record_sel
         gather_decs name_clause_map type_sig_names (x:xs)
           -- 1.
           | DFunD n clauses <- x
-          = if n `M.member` name_clause_map
-            then gather_decs (M.insertWith (\new old -> old ++ new)
-                                           n clauses name_clause_map)
-                             type_sig_names xs
-            else let (map', decs') = gather_decs (M.insert n clauses name_clause_map)
-                                                 type_sig_names xs
-                  in (map', x:decs')
+          = let name_clause_map' = M.insertWith (\new old -> old ++ new)
+                                                n clauses name_clause_map
+             in if n `M.member` name_clause_map
+                then gather_decs name_clause_map' type_sig_names xs
+                else let (map', decs') = gather_decs name_clause_map'
+                                           type_sig_names xs
+                      in (map', x:decs')
 
           -- 2.
           | DSigD n _ <- x

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -214,7 +214,7 @@ getRecordSelectors :: Quasi q
                    => DType        -- ^ the type of the argument
                    -> [DCon]
                    -> q [DLetDec]
-getRecordSelectors arg_ty cons = merge_let_decs <$> concatMapM get_record_sels cons
+getRecordSelectors arg_ty cons = merge_let_decs `fmap` concatMapM get_record_sels cons
   where
     get_record_sels (DCon _ _ con_name con _) = case con of
       DRecC fields -> go fields

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -13,7 +13,7 @@ module Language.Haskell.TH.Desugar.Util (
   impossible,
   nameOccursIn, allNamesIn, mkTypeName, mkDataName, isDataName,
   stripVarP_maybe, extractBoundNamesStmt,
-  concatMapM, mapMaybeM, expectJustM,
+  concatMapM, mapMaybeM, partitionWith, expectJustM,
   stripPlainTV_maybe,
   thirdOf3, splitAtList, extractBoundNamesDec,
   extractBoundNamesPat,
@@ -272,6 +272,15 @@ mapMaybeM f (x:xs) = do
   return $ case y of
     Nothing -> ys
     Just z  -> z : ys
+
+-- like GHC's
+partitionWith :: (a -> Either b c) -> [a] -> ([b], [c])
+-- ^ Uses a function to determine which of two output lists an input element should join
+partitionWith _ [] = ([],[])
+partitionWith f (x:xs) = case f x of
+                         Left  b -> (b:bs, cs)
+                         Right c -> (bs, c:cs)
+    where (bs,cs) = partitionWith f xs
 
 expectJustM :: Monad m => String -> Maybe a -> m a
 expectJustM _   (Just x) = return x

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -13,7 +13,7 @@ module Language.Haskell.TH.Desugar.Util (
   impossible,
   nameOccursIn, allNamesIn, mkTypeName, mkDataName, isDataName,
   stripVarP_maybe, extractBoundNamesStmt,
-  concatMapM, mapMaybeM, partitionWith, expectJustM,
+  concatMapM, mapMaybeM, expectJustM,
   stripPlainTV_maybe,
   thirdOf3, splitAtList, extractBoundNamesDec,
   extractBoundNamesPat,
@@ -272,15 +272,6 @@ mapMaybeM f (x:xs) = do
   return $ case y of
     Nothing -> ys
     Just z  -> z : ys
-
--- like GHC's
-partitionWith :: (a -> Either b c) -> [a] -> ([b], [c])
--- ^ Uses a function to determine which of two output lists an input element should join
-partitionWith _ [] = ([],[])
-partitionWith f (x:xs) = case f x of
-                         Left  b -> (b:bs, cs)
-                         Right c -> (bs, c:cs)
-    where (bs,cs) = partitionWith f xs
 
 expectJustM :: Monad m => String -> Maybe a -> m a
 expectJustM _   (Just x) = return x

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -72,7 +72,7 @@ $(dsDecSplice S.dectest13)
 $(do decs <- S.rec_sel_test
      [DDataD nd [] name [DPlainTV tvbName] cons []] <- dsDecs decs
      let arg_ty = (DConT name) `DAppT` (DVarT tvbName)
-     recsels <- fmap concat $ mapM (getRecordSelectors arg_ty) cons
+     recsels <- getRecordSelectors arg_ty cons
      let num_sels = length recsels `div` 2 -- ignore type sigs
      when (num_sels /= S.rec_sel_test_num_sels) $
        reportError $ "Wrong number of record selectors extracted.\n"


### PR DESCRIPTION
This migrates the changes I originally put forth in https://github.com/goldfirere/singletons/pull/181 to the site of `getRecordSelectors`' definition. `getRecordSelectors` now requires a _list_ of `DCons` instead of just one, which should make it harder to trigger the bug in https://github.com/goldfirere/singletons/issues/180.