### PR TITLE
Fix #56 by adding DDeclaredInfix to DNormalC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,8 @@
 
 next
 ----
-* Add `DInfixC` constructor for `DConFields` to represent data constructors
-  that are declard infix.
+* Incorporate a `DDeclaredInfix` field into `DNormalC` to indicate if it is
+  a constructor that was declared infix.
 
 Version 1.7
 -----------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 `th-desugar` release notes
 ==========================
 
+next
+----
+* Add `DInfixC` constructor for `DConFields` to represent data constructors
+  that are declard infix.
+
 Version 1.7
 -----------
 * Support for TH's support for `TypeApplications`, thanks to @RyanGlScott.

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -28,7 +28,7 @@ module Language.Haskell.TH.Desugar (
   DDerivClause(..), DerivStrategy(..), DPatSynDir(..), DPatSynType,
   Overlap(..), PatSynArgs(..), NewOrData(..),
   DTypeFamilyHead(..), DFamilyResultSig(..), InjectivityAnn(..),
-  DCon(..), DConFields(..), DBangType, DVarBangType,
+  DCon(..), DConFields(..), DDeclaredInfix, DBangType, DVarBangType,
   Bang(..), SourceUnpackedness(..), SourceStrictness(..),
   DForeign(..),
   DPragma(..), DRuleBndr(..), DTySynEqn(..), DInfo(..), DInstanceDec,

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -219,6 +219,8 @@ conToTH :: DCon -> Con
 #if __GLASGOW_HASKELL__ > 710
 conToTH (DCon [] [] n (DNormalC stys) (Just rty)) =
   GadtC [n] (map (second typeToTH) stys) (typeToTH rty)
+conToTH (DCon [] [] n (DInfixC sty1 sty2) (Just rty)) =
+  GadtC [n] (map (second typeToTH) [sty1,sty2]) (typeToTH rty)
 conToTH (DCon [] [] n (DRecC vstys) (Just rty)) =
   RecGadtC [n] (map (thirdOf3 typeToTH) vstys) (typeToTH rty)
 #endif
@@ -227,6 +229,12 @@ conToTH (DCon [] [] n (DNormalC stys) _) =
   NormalC n (map (second typeToTH) stys)
 #else
   NormalC n (map (bangToStrict *** typeToTH) stys)
+#endif
+conToTH (DCon [] [] n (DInfixC sty1 sty2) _) =
+#if __GLASGOW_HASKELL__ > 710
+  InfixC (second typeToTH sty1) n (second typeToTH sty2)
+#else
+  InfixC ((bangToStrict *** typeToTH) sty1) n ((bangToStrict *** typeToTH) sty2)
 #endif
 conToTH (DCon [] [] n (DRecC vstys) _) =
 #if __GLASGOW_HASKELL__ > 710

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -21,7 +21,7 @@ module Language.Haskell.TH.Desugar.Util (
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   tupleDegree_maybe, tupleNameDegree_maybe, unboxedTupleDegree_maybe,
   unboxedTupleNameDegree_maybe, splitTuple_maybe,
-  topEverywhereM
+  topEverywhereM, isInfixDataCon
   ) where
 
 import Prelude hiding (mapM, foldl, concatMap, any)
@@ -290,3 +290,9 @@ firstMatch f xs = listToMaybe $ mapMaybe f xs
 topEverywhereM :: (Typeable a, Data b, Monad m) => (a -> m a) -> b -> m b
 topEverywhereM handler =
   gmapM (topEverywhereM handler) `extM` handler
+
+-- Checks if a String names a valid Haskell infix data constructor
+-- (i.e., does it begin with a colon?).
+isInfixDataCon :: String -> Bool
+isInfixDataCon (':':_) = True
+isInfixDataCon _ = False

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -39,6 +39,8 @@ $(S.dectest11)
 #endif
 $(S.dectest12)
 $(S.dectest13)
+$(S.dectest14)
+$(S.dectest15)
 
 $(fmap unqualify S.instance_test)
 

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -40,7 +40,10 @@ $(S.dectest11)
 $(S.dectest12)
 $(S.dectest13)
 $(S.dectest14)
+
+#if __GLASGOW_HASKELL__ >= 710
 $(S.dectest15)
+#endif
 
 $(fmap unqualify S.instance_test)
 

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -68,6 +68,8 @@ $(dsDecSplice S.deriv_strat_test)
 
 $(dsDecSplice S.dectest12)
 $(dsDecSplice S.dectest13)
+$(dsDecSplice S.dectest14)
+$(dsDecSplice S.dectest15)
 
 $(do decs <- S.rec_sel_test
      [DDataD nd [] name [DPlainTV tvbName] cons []] <- dsDecs decs
@@ -79,6 +81,7 @@ $(do decs <- S.rec_sel_test
                   ++ "Wanted " ++ show S.rec_sel_test_num_sels
                   ++ ", Got " ++ show num_sels
      let unrecord c@(DCon _ _ _ (DNormalC {}) _) = c
+         unrecord c@(DCon _ _ _ (DInfixC {})  _) = c
          unrecord (DCon tvbs cxt con_name (DRecC fields) rty) =
            let (_names, stricts, types) = unzip3 fields
                fields' = zip stricts types

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -69,7 +69,10 @@ $(dsDecSplice S.deriv_strat_test)
 $(dsDecSplice S.dectest12)
 $(dsDecSplice S.dectest13)
 $(dsDecSplice S.dectest14)
+
+#if __GLASGOW_HASKELL__ >= 710
 $(dsDecSplice S.dectest15)
+#endif
 
 $(do decs <- S.rec_sel_test
      [DDataD nd [] name [DPlainTV tvbName] cons []] <- dsDecs decs

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -84,11 +84,10 @@ $(do decs <- S.rec_sel_test
                   ++ "Wanted " ++ show S.rec_sel_test_num_sels
                   ++ ", Got " ++ show num_sels
      let unrecord c@(DCon _ _ _ (DNormalC {}) _) = c
-         unrecord c@(DCon _ _ _ (DInfixC {})  _) = c
          unrecord (DCon tvbs cxt con_name (DRecC fields) rty) =
            let (_names, stricts, types) = unzip3 fields
                fields' = zip stricts types
            in
-           DCon tvbs cxt con_name (DNormalC fields') rty
+           DCon tvbs cxt con_name (DNormalC False fields') rty
          plaindata = [DDataD nd [] name [DPlainTV tvbName] (map unrecord cons) []]
      return (decsToTH plaindata ++ mapMaybe letDecToTH recsels))

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -365,6 +365,16 @@ dectest13 = [d| data Dec13 :: (* -> Constraint) -> * where
                   MkDec13 :: c a => a -> Dec13 c
               |]
 
+dectest14 = [d| data InfixADT = Int `InfixADT` Int |]
+
+dectest15 = [d| infixl 5 :**:, :&&:, :^^:, `ActuallyPrefix`
+                data InfixGADT a where
+                  (:**:) :: Int -> b -> InfixGADT (Maybe b) -- Only this one is infix
+                  (:&&:) :: { infixGADT1 :: b, infixGADT2 :: Int } -> InfixGADT [b]
+                  ActuallyPrefix :: Char -> Bool -> InfixGADT Double
+                  (:^^:) :: Int -> Int -> Int -> InfixGADT Int
+                  (:!!:) :: Char -> Char -> InfixGADT Char |]
+
 instance_test = [d| instance (Show a, Show b) => Show (a -> b) where
                        show _ = "function" |]
 


### PR DESCRIPTION
This adds the `DInfixC` constructor to `DConFields` to support the ability to query whether a data constructor is declared infix. This supports both regular ADTs as well as GADTs, which have more sophisticated rules for determining when a constructor is declared infix (see the comments in `Language.Haskell.TH.Desugar.Core`.

Fixes #56.