### PR TITLE
Don't crash when expanding quasiquoted type families

### DIFF
--- a/Language/Haskell/TH/Desugar/Expand.hs
+++ b/Language/Haskell/TH/Desugar/Expand.hs
@@ -118,8 +118,11 @@ expand_con ign n args = do
 #endif
       -> do
         let (syn_args, rest_args) = splitAtList tvbs args
-        -- need to get the correct instance
-        insts <- qReifyInstances n (map typeToTH syn_args)
+        -- We need to get the correct instance. If we fail to reify anything
+        -- (e.g., if a type family is quasiquoted), then fall back by
+        -- pretending that there are no instances in scope.
+        insts <- qRecover (return []) $
+                 qReifyInstances n (map typeToTH syn_args)
         dinsts <- dsDecs insts
         case dinsts of
           [DTySynInstD _n (DTySynEqn lhs rhs)] -> do


### PR DESCRIPTION
I discovered this when working on https://github.com/goldfirere/singletons/issues/198. If you compile this with `th-desugar-1.7`:

```haskell
{-# LANGUAGE TemplateHaskell #-}
module Bug where

import Language.Haskell.TH
import Language.Haskell.TH.Desugar
import Language.Haskell.TH.Desugar.Lift

test_local_tyfam_expansion :: Bool
test_local_tyfam_expansion =
  $(do fam_name <- newName "Fam"
       let orig_ty = DConT fam_name
       exp_ty <- withLocalDeclarations
                   (decsToTH [ DOpenTypeFamilyD (DTypeFamilyHead fam_name [] DNoSig Nothing)
                             , DTySynInstD fam_name (DTySynEqn [] (DConT ''Int)) ])
                   (expandType orig_ty)
       [| orig_ty == exp_ty |])
```

It'll break:

```
GHCi, version 8.2.0.20170523: http://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/rgscott/.ghci
[1 of 1] Compiling Bug              ( Bug.hs, interpreted )

Bug.hs:10:5: error:
    • The exact Name ‘Fam_a7Co’ is not in scope
        Probable cause: you used a unique Template Haskell name (NameU), 
        perhaps via newName, but did not bind it
        If that's it, then -ddump-splices might be useful
    • In the argument of reifyInstances: Fam_0
      In the untyped splice:
        $(do fam_name <- newName "Fam"
             let orig_ty = DConT fam_name
             exp_ty <- withLocalDeclarations
                         (decsToTH
                            [DOpenTypeFamilyD (DTypeFamilyHead fam_name [] DNoSig Nothing),
                             DTySynInstD fam_name (DTySynEqn [] (DConT ''Int))])
                         (expandType orig_ty)
             [| orig_ty == exp_ty |])
   |
10 |   $(do fam_name <- newName "Fam"
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^...

Bug.hs:10:5: error:
    • GHC internal error: ‘Fam_a7Co’ is not in scope during type checking, but it passed the renamer
      tcl_env of environment: []
    • In the type ‘Fam_a7Co’
      In the argument of reifyInstances: Fam_0
      In the untyped splice:
        $(do fam_name <- newName "Fam"
             let orig_ty = DConT fam_name
             exp_ty <- withLocalDeclarations
                         (decsToTH
                            [DOpenTypeFamilyD (DTypeFamilyHead fam_name [] DNoSig Nothing),
                             DTySynInstD fam_name (DTySynEqn [] (DConT ''Int))])
                         (expandType orig_ty)
             [| orig_ty == exp_ty |])
   |
10 |   $(do fam_name <- newName "Fam"
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

That GHC internal error is due to [Trac #13837](https://ghc.haskell.org/trac/ghc/ticket/13837), but that's a separate problem. The more pressing issue is that `reifyInstances` is failing at all. This happens because a use of `qReifyInstances` in `expand_con` fails when a type family is declared locally (e.g., in quasiquotes).

This PR simply guards that use of `qReifyInstances` with `qRecover`. In an ideal world, we'd have `qReifyInstancesWithLocals`, but that would require implementing instance lookup in `th-desugar`, which sounds far above my paygrade. This is a much simpler solution.