### PR TITLE
Fix #59 by adding special cases for empty record constructions and patterns

### DIFF
--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -379,11 +379,16 @@ dsExp (SigE exp ty) = DSigE <$> dsExp exp <*> dsType ty
 dsExp (RecConE con_name field_exps) = do
   con <- dataConNameToCon con_name
   reordered <- case con of
-                 RecC _name fields -> reorderFields fields field_exps
-                                                    (repeat $ DVarE 'undefined)
+                 RecC _name fields -> reorder_fields fields
+#if __GLASGOW_HASKELL__ >= 800
+                 RecGadtC _names fields _ret_ty -> reorder_fields fields
+#endif
                  _ -> impossible $ "Record syntax used with non-record constructor "
                                    ++ (show con_name) ++ "."
   return $ foldl DAppE (DConE con_name) reordered
+  where
+    reorder_fields fields = reorderFields fields field_exps
+                                          (repeat $ DVarE 'undefined)
 dsExp (RecUpdE exp field_exps) = do
   -- here, we need to use one of the field names to find the tycon, somewhat dodgily
   first_name <- case field_exps of
@@ -422,19 +427,33 @@ dsExp (RecUpdE exp field_exps) = do
     filter_cons_with_names cons field_names =
       filter has_names cons
       where
-        has_names (RecC _con_name args) =
+        args_contain_names args =
           let con_field_names = map fst_of_3 args in
           all (`elem` con_field_names) field_names
+
+        has_names (RecC _con_name args) =
+          args_contain_names args
+#if __GLASGOW_HASKELL__ >= 800
+        has_names (RecGadtC _con_name args _ret_ty) =
+          args_contain_names args
+#endif
         has_names (ForallC _ _ c) = has_names c
         has_names _               = False
 
-    con_to_dmatch :: DsMonad q => Con -> q DMatch
-    con_to_dmatch (RecC con_name args) = do
+    rec_con_to_dmatch con_name args = do
       let con_field_names = map fst_of_3 args
       field_var_names <- mapM (newUniqueName . nameBase) con_field_names
       DMatch (DConPa con_name (map DVarPa field_var_names)) <$>
              (foldl DAppE (DConE con_name) <$>
                     (reorderFields args field_exps (map DVarE field_var_names)))
+
+    con_to_dmatch :: DsMonad q => Con -> q DMatch
+    con_to_dmatch (RecC con_name args) = rec_con_to_dmatch con_name args
+#if __GLASGOW_HASKELL__ >= 800
+    -- We're assuming the GADT constructor has only one Name here, but since
+    -- this constructor was reified, this assumption should always hold true.
+    con_to_dmatch (RecGadtC [con_name] args _ret_ty) = rec_con_to_dmatch con_name args
+#endif
     con_to_dmatch (ForallC _ _ c) = con_to_dmatch c
     con_to_dmatch _ = impossible "Internal error within th-desugar."
 
@@ -659,10 +678,15 @@ dsPat WildP = return DWildPa
 dsPat (RecP con_name field_pats) = do
   con <- lift $ dataConNameToCon con_name
   reordered <- case con of
-    RecC _name fields -> reorderFieldsPat fields field_pats
+    RecC _name fields -> reorder_fields_pat fields
+#if __GLASGOW_HASKELL__ >= 800
+    RecGadtC _names fields _ret_ty -> reorder_fields_pat fields
+#endif
     _ -> lift $ impossible $ "Record syntax used with non-record constructor "
                              ++ (show con_name) ++ "."
   return $ DConPa con_name reordered
+  where
+    reorder_fields_pat fields = reorderFieldsPat fields field_pats
 dsPat (ListP pats) = go pats
   where go [] = return $ DConPa '[] []
         go (h : t) = do

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -462,9 +462,12 @@ findCon n = find match_con
 findRecSelector :: Name -> [Con] -> Maybe Type
 findRecSelector n = firstMatch match_con
   where
-    match_con (RecC _ vstys)  = firstMatch match_rec_sel vstys
-    match_con (ForallC _ _ c) = match_con c
-    match_con _               = Nothing
+    match_con (RecC _ vstys)       = firstMatch match_rec_sel vstys
+#if __GLASGOW_HASKELL__ >= 800
+    match_con (RecGadtC _ vstys _) = firstMatch match_rec_sel vstys
+#endif
+    match_con (ForallC _ _ c)      = match_con c
+    match_con _                    = Nothing
 
     match_rec_sel (n', _, ty) | n `nameMatches` n' = Just ty
     match_rec_sel _                     = Nothing

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -243,6 +243,11 @@ test44_let_pragma = [| let x :: Int
                            {-# INLINE x #-}
                        in x |]
 
+test45_empty_record_con = [| let j :: Maybe Int
+                                 j = Just{}
+                             in case j of
+                                Nothing -> j
+                                Just{}  -> j |]
 
 type family TFExpand x
 type instance TFExpand Int = Bool
@@ -594,4 +599,5 @@ test_exprs = [ test1_sections
              , test43_ubx_sums
 #endif
              , test44_let_pragma
+             , test45_empty_record_con
              ]


### PR DESCRIPTION
This allows the use of `Con{}` in expressions and patterns, regardless of whether `Con` was actually declared with records or not. Fixes #59.