### PR TITLE
Add (Maybe DKind) field to DDataD/DDataFamilyD/DDataInstD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 1.8
 * Incorporate a `DDeclaredInfix` field into `DNormalC` to indicate if it is
   a constructor that was declared infix.
 
+* Incorporate a `Maybe DKind` field into `DDataD`, `DDataFamilyD`, and
+  `DDataInstD` to reflect the return kind of a datatype or data family (if it
+  was declared with an explicit one).
+
 * Implement `lookupValueNameWithLocals`, `lookupTypeNameWithLocals`,
   `mkDataNameWithLocals`, and `mkTypeNameWithLocals`, counterparts to
   `lookupValueName`, `lookupTypeName`, `mkDataName`, and `mkTypeName` which

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -330,9 +330,9 @@ mkDataConCase var case_alts = do
       Just (DTyConI tycon_dec _) <- dsReify ty_name
       return $ S.fromList $ map get_con_name $ get_cons tycon_dec
 
-    get_cons (DDataD _ _ _ _ cons _)     = cons
-    get_cons (DDataInstD _ _ _ _ cons _) = cons
-    get_cons _                           = []
+    get_cons (DDataD _ _ _ _ _ cons _)     = cons
+    get_cons (DDataInstD _ _ _ _ _ cons _) = cons
+    get_cons _                             = []
 
     get_con_name (DCon _ _ n _ _) = n
 

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -85,17 +85,17 @@ decsToTH = concatMap decToTH
 -- a one-to-one mapping between 'DDec' and @Dec@.
 decToTH :: DDec -> [Dec]
 decToTH (DLetDec d) = maybeToList (letDecToTH d)
-decToTH (DDataD Data cxt n tvbs cons derivings) =
+decToTH (DDataD Data cxt n tvbs _mk cons derivings) =
 #if __GLASGOW_HASKELL__ > 710
-  [DataD (cxtToTH cxt) n (map tvbToTH tvbs) Nothing (map conToTH cons)
+  [DataD (cxtToTH cxt) n (map tvbToTH tvbs) (fmap typeToTH _mk) (map conToTH cons)
          (concatMap derivClauseToTH derivings)]
 #else
   [DataD (cxtToTH cxt) n (map tvbToTH tvbs) (map conToTH cons)
          (map derivingToTH derivings)]
 #endif
-decToTH (DDataD Newtype cxt n tvbs [con] derivings) =
+decToTH (DDataD Newtype cxt n tvbs _mk [con] derivings) =
 #if __GLASGOW_HASKELL__ > 710
-  [NewtypeD (cxtToTH cxt) n (map tvbToTH tvbs) Nothing (conToTH con)
+  [NewtypeD (cxtToTH cxt) n (map tvbToTH tvbs) (fmap typeToTH _mk) (conToTH con)
             (concatMap derivClauseToTH derivings)]
 #else
   [NewtypeD (cxtToTH cxt) n (map tvbToTH tvbs) (conToTH con)
@@ -119,23 +119,23 @@ decToTH (DOpenTypeFamilyD (DTypeFamilyHead n tvbs frs ann)) =
 decToTH (DOpenTypeFamilyD (DTypeFamilyHead n tvbs frs _ann)) =
   [FamilyD TypeFam n (map tvbToTH tvbs) (frsToTH frs)]
 #endif
-decToTH (DDataFamilyD n tvbs) =
+decToTH (DDataFamilyD n tvbs mk) =
 #if __GLASGOW_HASKELL__ > 710
-  [DataFamilyD n (map tvbToTH tvbs) Nothing]
+  [DataFamilyD n (map tvbToTH tvbs) (fmap typeToTH mk)]
 #else
-  [FamilyD DataFam n (map tvbToTH tvbs) Nothing]
+  [FamilyD DataFam n (map tvbToTH tvbs) (fmap typeToTH mk)]
 #endif
-decToTH (DDataInstD Data cxt n tys cons derivings) =
+decToTH (DDataInstD Data cxt n tys _mk cons derivings) =
 #if __GLASGOW_HASKELL__ > 710
-  [DataInstD (cxtToTH cxt) n (map typeToTH tys) Nothing (map conToTH cons)
+  [DataInstD (cxtToTH cxt) n (map typeToTH tys) (fmap typeToTH _mk) (map conToTH cons)
              (concatMap derivClauseToTH derivings)]
 #else
   [DataInstD (cxtToTH cxt) n (map typeToTH tys) (map conToTH cons)
              (map derivingToTH derivings)]
 #endif
-decToTH (DDataInstD Newtype cxt n tys [con] derivings) =
+decToTH (DDataInstD Newtype cxt n tys _mk [con] derivings) =
 #if __GLASGOW_HASKELL__ > 710
-  [NewtypeInstD (cxtToTH cxt) n (map typeToTH tys) Nothing (conToTH con)
+  [NewtypeInstD (cxtToTH cxt) n (map typeToTH tys) (fmap typeToTH _mk) (conToTH con)
                 (concatMap derivClauseToTH derivings)]
 #else
   [NewtypeInstD (cxtToTH cxt) n (map typeToTH tys) (conToTH con)

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -75,7 +75,7 @@ $(dsDecSplice S.dectest15)
 #endif
 
 $(do decs <- S.rec_sel_test
-     [DDataD nd [] name [DPlainTV tvbName] cons []] <- dsDecs decs
+     [DDataD nd [] name [DPlainTV tvbName] Nothing cons []] <- dsDecs decs
      let arg_ty = (DConT name) `DAppT` (DVarT tvbName)
      recsels <- getRecordSelectors arg_ty cons
      let num_sels = length recsels `div` 2 -- ignore type sigs
@@ -89,5 +89,5 @@ $(do decs <- S.rec_sel_test
                fields' = zip stricts types
            in
            DCon tvbs cxt con_name (DNormalC False fields') rty
-         plaindata = [DDataD nd [] name [DPlainTV tvbName] (map unrecord cons) []]
+         plaindata = [DDataD nd [] name [DPlainTV tvbName] Nothing (map unrecord cons) []]
      return (decsToTH plaindata ++ mapMaybe letDecToTH recsels))


### PR DESCRIPTION
The inability to express data types and data families with explicit return kinds prevents one from using `th-desugar` to construct certain data type signatures (e.g., `data Foo :: forall (a :: k). Proxy a -> Type`, or what is requested in https://github.com/goldfirere/singletons/issues/216#issuecomment-320037390), so this PR adds that ability.

Previously, we were awkwardly converting the return kinds of data types and data families into `DTyVarBndr`s. Now that we have explicit fields for return kinds, this is no longer necessary, allowing us to remove the dreaded `mkExtraTvbs` function.

There were already a number of tests that reify datatypes with return kinds like `:: * -> *`, so I opted not to clutter the test suite with more tests of that ilk. (I would test quoting something exotic like `data Foo :: forall k. k -> Type`, but that capability is only present in GHC HEAD, so I decided it wouldn't be worth it.)