### PR TITLE
Make substTy kind-aware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 Version 1.8
 -----------
+* `substTy` now properly substitutes into kind signatures.
+
+* Implement `freeVarsOfTy`, which computes the free variables of a `DType`.
+
 * Incorporate a `DDeclaredInfix` field into `DNormalC` to indicate if it is
   a constructor that was declared infix.
 

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -82,7 +82,7 @@ module Language.Haskell.TH.Desugar (
   nameOccursIn, allNamesIn, flattenDValD, getRecordSelectors,
   mkTypeName, mkDataName, newUniqueName,
   mkTupleDExp, mkTupleDPat, maybeDLetE, maybeDCaseE,
-  substTy,
+  substTy, freeVarsOfTy,
   tupleDegree_maybe, tupleNameDegree_maybe,
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   unboxedTupleDegree_maybe, unboxedTupleNameDegree_maybe,


### PR DESCRIPTION
Previously, `substTy` was incorrectly substituting variables in kind signatures. This fixes that.

In order to test this functionality, I found myself needing a function `freeVarsOfTy :: DType -> Set Name`, so I decided to expose this alongside `substTy`.

Fixes #66.