### PR TITLE
Remove DStarT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 `th-desugar` release notes
 ==========================
 
+Version 1.9
+-----------
+* Remove the `DStarT` constructor of `DType` in favor of `DConT ''Type`.
+  Two utility functions have been added to `Language.Haskell.TH.Desugar` to
+  ease this transition:
+
+  * `isTypeKindName`: returns `True` if the argument `Name` is that
+    of `Type` (or `*`, to support older GHCs).
+  * `typeKindName`: the name of `Type` (on GHC 8.0 or later) or `*` (on older
+    GHCs).
+
 Version 1.8
 -----------
 * Support GHC 8.4.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Version 1.9
   ease this transition:
 
   * `isTypeKindName`: returns `True` if the argument `Name` is that
-    of `Type` (or `*`, to support older GHCs).
+    of `Type` or `★` (or `*`, to support older GHCs).
   * `typeKindName`: the name of `Type` (on GHC 8.0 or later) or `*` (on older
     GHCs).
 

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -89,7 +89,7 @@ module Language.Haskell.TH.Desugar (
   tupleDegree_maybe, tupleNameDegree_maybe,
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   unboxedTupleDegree_maybe, unboxedTupleNameDegree_maybe,
-  strictToBang,
+  strictToBang, isTypeKindName, typeKindName,
 
   -- ** Extracting bound names
   extractBoundNamesStmt, extractBoundNamesDec, extractBoundNamesPat
@@ -193,7 +193,6 @@ fvDType = go_ty
     go_ty DArrowT                = S.empty
     go_ty (DLitT {})             = S.empty
     go_ty DWildCardT             = S.empty
-    go_ty DStarT                 = S.empty
 
     go_pred :: DPred -> S.Set Name
     go_pred (DAppPr pr ty) = go_pred pr <> go_ty ty

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -76,7 +76,6 @@ data DType = DForallT [DTyVarBndr] DCxt DType
            | DArrowT
            | DLitT TyLit
            | DWildCardT
-           | DStarT
            deriving (Show, Typeable, Data, Generic)
 
 -- | Kinds are types.
@@ -1204,7 +1203,7 @@ dsType ListT = return $ DConT ''[]
 dsType (PromotedTupleT n) = return $ DConT (tupleDataName n)
 dsType PromotedNilT = return $ DConT '[]
 dsType PromotedConsT = return $ DConT '(:)
-dsType StarT = return DStarT
+dsType StarT = return $ DConT typeKindName
 dsType ConstraintT = return $ DConT ''Constraint
 dsType (LitT lit) = return $ DLitT lit
 #if __GLASGOW_HASKELL__ >= 709
@@ -1404,4 +1403,3 @@ dTypeToDPred (DConT n)       = return $ DConPr n
 dTypeToDPred DArrowT         = impossible "Arrow used as head of constraint"
 dTypeToDPred (DLitT _)       = impossible "Type literal used as head of constraint"
 dTypeToDPred DWildCardT      = return DWildCardPr
-dTypeToDPred DStarT          = impossible "Star used as head of constraint"

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -305,7 +305,6 @@ typeToTH DWildCardT = WildCardT
 #else
 typeToTH DWildCardT = error "Wildcards supported only in GHC 8.0+"
 #endif
-typeToTH DStarT = StarT
 
 tvbToTH :: DTyVarBndr -> TyVarBndr
 tvbToTH (DPlainTV n)           = PlainTV n
@@ -369,6 +368,10 @@ tyconToTH n
                                                  then PromotedTupleT deg
                                                  else TupleT deg
   | Just deg <- unboxedTupleNameDegree_maybe n = UnboxedTupleT deg
+#if __GLASGOW_HASKELL__ == 706
+    -- Work around Trac #7667
+  | isTypeKindName n            = StarT
+#endif
 #if __GLASGOW_HASKELL__ >= 801
   | Just deg <- unboxedSumNameDegree_maybe n   = UnboxedSumT deg
 #endif

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -6,7 +6,11 @@ rae@cs.brynmawr.edu
 Utility functions for th-desugar package.
 -}
 
-{-# LANGUAGE CPP, TupleSections #-}
+{-# LANGUAGE CPP, ExplicitNamespaces, TupleSections #-}
+
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE TemplateHaskellQuotes #-}
+#endif
 
 module Language.Haskell.TH.Desugar.Util (
   newUniqueName,
@@ -21,7 +25,8 @@ module Language.Haskell.TH.Desugar.Util (
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   tupleDegree_maybe, tupleNameDegree_maybe, unboxedTupleDegree_maybe,
   unboxedTupleNameDegree_maybe, splitTuple_maybe,
-  topEverywhereM, isInfixDataCon
+  topEverywhereM, isInfixDataCon,
+  isTypeKindName, typeKindName
   ) where
 
 import Prelude hiding (mapM, foldl, concatMap, any)
@@ -34,6 +39,10 @@ import Data.Foldable
 import Data.Generics hiding ( Fixity )
 import Data.Traversable
 import Data.Maybe
+
+#if __GLASGOW_HASKELL__ >= 800
+import qualified Data.Kind as Kind (Type, type (*))
+#endif
 
 #if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
@@ -319,3 +328,27 @@ topEverywhereM handler =
 isInfixDataCon :: String -> Bool
 isInfixDataCon (':':_) = True
 isInfixDataCon _ = False
+
+-- | Returns 'True' if the argument 'Name' is that of 'Kind.Type'
+-- (or @*@, to support older GHCs).
+isTypeKindName :: Name -> Bool
+isTypeKindName n = n == starKindName || n == typeKindName
+
+-- | The 'Name' of:
+--
+-- 1. The kind 'Kind.Type', on GHC 8.0 or later.
+-- 2. The kind @*@ on older GHCs.
+typeKindName :: Name
+#if __GLASGOW_HASKELL__ >= 800
+typeKindName = ''Kind.Type
+#else
+typeKindName = starKindName
+#endif
+
+-- | The 'Name' of the kind @*@.
+starKindName :: Name
+#if __GLASGOW_HASKELL__ >= 800
+starKindName = ''(Kind.*)
+#else
+starKindName = mkNameG_tc "ghc-prim" "GHC.Prim" "*"
+#endif

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -6,7 +6,7 @@ rae@cs.brynmawr.edu
 Utility functions for th-desugar package.
 -}
 
-{-# LANGUAGE CPP, ExplicitNamespaces, TupleSections #-}
+{-# LANGUAGE CPP, TupleSections #-}
 
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TemplateHaskellQuotes #-}
@@ -41,7 +41,7 @@ import Data.Traversable
 import Data.Maybe
 
 #if __GLASGOW_HASKELL__ >= 800
-import qualified Data.Kind as Kind (Type, type (*))
+import qualified Data.Kind as Kind
 #endif
 
 #if __GLASGOW_HASKELL__ < 804
@@ -329,10 +329,12 @@ isInfixDataCon :: String -> Bool
 isInfixDataCon (':':_) = True
 isInfixDataCon _ = False
 
--- | Returns 'True' if the argument 'Name' is that of 'Kind.Type'
+-- | Returns 'True' if the argument 'Name' is that of 'Kind.Type' or 'Kind.★'
 -- (or @*@, to support older GHCs).
 isTypeKindName :: Name -> Bool
-isTypeKindName n = n == starKindName || n == typeKindName
+isTypeKindName n = n == starKindName
+                || n == typeKindName
+                || n == uniStarKindName
 
 -- | The 'Name' of:
 --
@@ -351,4 +353,15 @@ starKindName :: Name
 starKindName = ''(Kind.*)
 #else
 starKindName = mkNameG_tc "ghc-prim" "GHC.Prim" "*"
+#endif
+
+-- | The 'Name' of:
+--
+-- 1. The kind 'Kind.★', on GHC 8.0 or later.
+-- 2. The kind @*@ on older GHCs.
+uniStarKindName :: Name
+#if __GLASGOW_HASKELL__ >= 800
+uniStarKindName = ''(Kind.★)
+#else
+uniStarKindName = starKindName
 #endif

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -201,11 +201,13 @@ test_bug8884 = $(do info <- reify ''Poly
                     dinfo@(DTyConI (DOpenTypeFamilyD (DTypeFamilyHead _name _tvbs (DKindSig resK) _ann))
                                    (Just [DTySynInstD _name2 (DTySynEqn lhs _rhs)]))
                       <- dsInfo info
-                    case (resK, lhs) of
+                    let isTypeKind (DConT n) = isTypeKindName n
+                        isTypeKind _         = False
+                    case (isTypeKind resK, lhs) of
 #if __GLASGOW_HASKELL__ < 709
-                      (DStarT, [DVarT _]) -> [| True |]
+                      (True, [DVarT _]) -> [| True |]
 #else
-                      (DStarT, [DSigT (DVarT _) (DVarT _)]) -> [| True |]
+                      (True, [DSigT (DVarT _) (DVarT _)]) -> [| True |]
 #endif
                       _                                     -> do
                         runIO $ do

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -362,7 +362,7 @@ ds_dectest10 = DClosedTypeFamilyD
                  (DTypeFamilyHead
                     (mkName "Dec10")
                     [DPlainTV (mkName "a")]
-                    (DKindSig (DAppT (DAppT DArrowT DStarT) DStarT))
+                    (DKindSig (DAppT (DAppT DArrowT (DConT typeKindName)) (DConT typeKindName)))
                     Nothing)
                  [ DTySynEqn [DConT ''Int]  (DConT ''Maybe)
                  , DTySynEqn [DConT ''Bool] (DConT ''[]) ]

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -1,5 +1,5 @@
 name:           th-desugar
-version:        1.8
+version:        1.9
 cabal-version:  >= 1.10
 synopsis:       Functions to desugar Template Haskell
 homepage:       https://github.com/goldfirere/th-desugar


### PR DESCRIPTION
Fixes #69.

The only true surprise here was that `expand` had to be changed in order to avoid infintely looping when expanding `Type`. See `Note [Don't expand synonyms for *]` for the gory details.