### PR TITLE
Fix #60 by rejecting constructor-record mismatches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ Version 1.9
 * Add a `mkDLamEFromDPats` function for constructing a `DLamE` expression using
   a list of `DPat` arguments and a `DExp` body.
 
+* Previously, `th-desugar` would silently accept illegal uses of record
+  construction with fields that did not belong to the constructor, such as
+  `Identity { notAField = "wat" }`. This is now an error.
+
 Version 1.8
 -----------
 * Support GHC 8.4.


### PR DESCRIPTION
This adds a simple validity check to ensure that one does not attempt to combine a record constructor with a record that does not belong to it in a record construction expression or record pattern match, such as `Identity { getCompose = "wat" }`.

Fixes #60.