### PR TITLE
Desugar all data types to GADT syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,9 +16,9 @@ Version 1.9
   API-facing changes resulting from this new design are:
 
   * The `DDataD`, `DDataFamilyD`, and `DDataFamInstD` constructors of `DDec`
-    now have `DKind` fields corresponding to explicit return kinds (e.g., the
-    `k -> Type -> Type` in `data Foo :: k -> Type -> Type`). If a data type was
-    written without an explicit return kind, this defaults to `Type`.
+    now have `Maybe DKind` fields that either have `Just` an explicit return
+    kind (e.g., the `k -> Type -> Type` in `data Foo :: k -> Type -> Type`)
+    or `Nothing` (if lacking an explicit return kind).
   * The `DCon` constructor previously had a field of type `Maybe DType`, since
     there was a possibility it could be a GADT (with an explicit return type)
     or non-GADT (without an explicit return type) constructor. Since all data
@@ -35,7 +35,12 @@ Version 1.9
     of `dsCon` is now:
 
     ```haskell
-    dsCon :: DsMonad q => [DTyVarBndr] -> DType -> Con -> q [DCon]
+    dsCon :: DsMonad q
+          => [DTyVarBndr] -- ^ The universally quantified type variables
+                          --   (used if desugaring a non-GADT constructor)
+          -> DType        -- ^ The original data declaration's type
+                          --   (used if desugaring a non-GADT constructor).
+          -> Con -> q [DCon]
     ```
 
     The `instance Desugar [Con] [DCon]` has also been removed, as the previous

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -312,7 +312,7 @@ mkExtraDKindBinders = expandType >=> mkExtraDKindBinders'
 --
 -- Detecting the presence of existentially quantified type variables in the
 -- context of Template Haskell is quite involved. Here is an example that
--- we will will use to explain how this works:
+-- we will use to explain how this works:
 --
 -- @
 -- data family Foo a b

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -90,6 +90,7 @@ module Language.Haskell.TH.Desugar (
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   unboxedTupleDegree_maybe, unboxedTupleNameDegree_maybe,
   strictToBang, isTypeKindName, typeKindName,
+  unravel, conExistentialTvbs, mkExtraDKindBinders,
 
   -- ** Extracting bound names
   extractBoundNamesStmt, extractBoundNamesDec, extractBoundNamesPat
@@ -104,12 +105,9 @@ import Language.Haskell.TH.Desugar.Expand
 import Language.Haskell.TH.Desugar.Match
 import Language.Haskell.TH.Desugar.Subst
 
+import Control.Monad
 import qualified Data.Map as M
-import Data.Monoid
 import qualified Data.Set as S
-#if __GLASGOW_HASKELL__ < 709
-import Data.Foldable ( foldMap )
-#endif
 import Prelude hiding ( exp )
 
 -- | This class relates a TH type with its th-desugar type and allows
@@ -139,10 +137,6 @@ instance Desugar TyVarBndr DTyVarBndr where
 instance Desugar [Dec] [DDec] where
   desugar = dsDecs
   sweeten = decsToTH
-
-instance Desugar [Con] [DCon] where
-  desugar = concatMapM dsCon
-  sweeten = map conToTH
 
 -- | If the declaration passed in is a 'DValD', creates new, equivalent
 -- declarations such that the 'DPat' in all 'DValD's is just a plain
@@ -180,34 +174,6 @@ flattenDValD (DValD pat exp) = do
 
 flattenDValD other_dec = return [other_dec]
 
-fvDType :: DType -> S.Set Name
-fvDType = go_ty
-  where
-    go_ty :: DType -> S.Set Name
-    go_ty (DForallT tvbs cxt ty) = (foldMap go_tvb tvbs <> go_ty ty <> foldMap go_pred cxt)
-                                   S.\\ foldMap dtvbName tvbs
-    go_ty (DAppT t1 t2)          = go_ty t1 <> go_ty t2
-    go_ty (DSigT ty ki)          = go_ty ty <> go_ty ki
-    go_ty (DVarT n)              = S.singleton n
-    go_ty (DConT {})             = S.empty
-    go_ty DArrowT                = S.empty
-    go_ty (DLitT {})             = S.empty
-    go_ty DWildCardT             = S.empty
-
-    go_pred :: DPred -> S.Set Name
-    go_pred (DAppPr pr ty) = go_pred pr <> go_ty ty
-    go_pred (DSigPr pr ki) = go_pred pr <> go_ty ki
-    go_pred (DVarPr n)     = S.singleton n
-    go_pred _              = S.empty
-
-    go_tvb :: DTyVarBndr -> S.Set Name
-    go_tvb (DPlainTV{})    = S.empty
-    go_tvb (DKindedTV _ k) = go_ty k
-
-dtvbName :: DTyVarBndr -> S.Set Name
-dtvbName (DPlainTV n)    = S.singleton n
-dtvbName (DKindedTV n _) = S.singleton n
-
 -- | Produces 'DLetDec's representing the record selector functions from
 -- the provided 'DCon's.
 --
@@ -228,9 +194,14 @@ dtvbName (DKindedTV n _) = S.singleton n
 -- @
 --
 -- instead of returning one binding for @X1@ and another binding for @X2@.
+--
+-- 'getRecordSelectors' attempts to filter out \"naughty\" record selectors
+-- whose types mention existentially quantified type variables. But see the
+-- documentation for 'conExistentialTvbs' for limitations to this approach.
 
 -- See https://github.com/goldfirere/singletons/issues/180 for an example where
 -- the latter behavior can bite you.
+
 getRecordSelectors :: Quasi q
                    => DType        -- ^ the type of the argument
                    -> [DCon]
@@ -318,3 +289,98 @@ getRecordSelectors arg_ty cons = merge_let_decs `fmap` concatMapM get_record_sel
           | DFunD n _ <- x, Just merged_clauses <- n `M.lookup` name_clause_map
           = DFunD n merged_clauses:augment_clauses name_clause_map xs
           | otherwise = x:augment_clauses name_clause_map xs
+
+-- | Create new kind variable binder names corresponding to the return kind of
+-- a data type. This is useful when you have a data type like:
+--
+-- @
+-- data Foo :: forall k. k -> Type -> Type where ...
+-- @
+--
+-- But you want to be able to refer to the type @Foo a b@.
+-- 'mkExtraDKindBinders' will take the kind @forall k. k -> Type -> Type@,
+-- discover that is has two visible argument kinds, and return as a result
+-- two new kind variable binders @[a :: k, b :: Type]@, where @a@ and @b@
+-- are fresh type variable names.
+--
+-- This expands kind synonyms if necessary.
+mkExtraDKindBinders :: DsMonad q => DKind -> q [DTyVarBndr]
+mkExtraDKindBinders = expandType >=> mkExtraDKindBinders'
+
+-- | Returns all of a constructor's existentially quantified type variable
+-- binders.
+--
+-- Detecting the presence of existentially quantified type variables in the
+-- context of Template Haskell is quite involved. Here is an example that
+-- we will will use to explain how this works:
+--
+-- @
+-- data family Foo a b
+-- data instance Foo (Maybe a) b where
+--   MkFoo :: forall x y z. x -> y -> z -> Foo (Maybe x) [z]
+-- @
+--
+-- In @MkFoo@, @x@ is universally quantified, whereas @y@ and @z@ are
+-- existentially quantified. Note that @MkFoo@ desugars (in Core) to
+-- something like this:
+--
+-- @
+-- data instance Foo (Maybe a) b where
+--   MkFoo :: forall a b y z. (b ~ [z]). a -> y -> z -> Foo (Maybe a) b
+-- @
+--
+-- Here, we can see that @a@ appears in the desugared return type (it is a
+-- simple alpha-renaming of @x@), so it is universally quantified. On the other
+-- hand, neither @y@ nor @z@ appear in the desugared return type, so they are
+-- existentially quantified.
+--
+-- This analysis would not have been possible without knowing what the original
+-- data declaration's type was (in this case, @Foo (Maybe a) b@), which is why
+-- we require it as an argument. Our algorithm for detecting existentially
+-- quantified variables is not too different from what was described above:
+-- we match the constructor's return type with the original data type, forming
+-- a substitution, and check which quantified variables are not part of the
+-- domain of the substitution.
+--
+-- Be warned: this may overestimate which variables are existentially
+-- quantified when kind variables are involved. For instance, consider this
+-- example:
+--
+-- @
+-- data S k (a :: k)
+-- data T a where
+--   MkT :: forall k (a :: k). { foo :: Proxy (a :: k), bar :: S k a } -> T a
+-- @
+--
+-- Here, the kind variable @k@ does not appear syntactically in the return type
+-- @T a@, so 'conExistentialTvbs' would mistakenly flag @k@ as existential.
+--
+-- There are various tricks we could employ to improve this, but ultimately,
+-- making this behave correctly with respect to @PolyKinds@ 100% of the time
+-- would amount to performing kind inference in Template Haskell, which is
+-- quite difficult. For the sake of simplicity, we have decided to stick with
+-- a dumb-but-predictable syntactic check.
+conExistentialTvbs :: DsMonad q
+                   => DType -- ^ The type of the original data declaration
+                   -> DCon
+                   -> q [DTyVarBndr]
+conExistentialTvbs data_ty (DCon tvbs _ _ _ ret_ty) =
+  -- Due to GHC Trac #13885, it's possible that the type variables bound by
+  -- a GADT constructor will shadow those that are bound by the data type.
+  -- This function assumes this isn't the case in certain parts (e.g., when
+  -- unifying types), so we do an alpha-renaming of the
+  -- constructor-bound variables before proceeding.
+  substTyVarBndrs M.empty tvbs $ \subst tvbs' -> do
+    renamed_ret_ty <- substTy subst ret_ty
+    data_ty'       <- expandType data_ty
+    ret_ty'        <- expandType renamed_ret_ty
+    case matchTy YesIgnore ret_ty' data_ty' of
+      Nothing -> fail $ showString "Unable to match type "
+                      . showsPrec 11 ret_ty'
+                      . showString " with "
+                      . showsPrec 11 data_ty'
+                      $ ""
+      Just gadtSubt -> return [ tvb
+                              | tvb <- tvbs'
+                              , M.notMember (dtvbName tvb) gadtSubt
+                              ]

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -1614,8 +1614,7 @@ fvDType :: DType -> S.Set Name
 fvDType = go_ty
   where
     go_ty :: DType -> S.Set Name
-    go_ty (DForallT tvbs cxt ty) = (foldMap go_tvb tvbs <> go_ty ty <> foldMap go_pred cxt)
-                                   S.\\ S.fromList (map dtvbName tvbs)
+    go_ty (DForallT tvbs cxt ty) = foldr go_tvb (foldMap go_pred cxt <> go_ty ty) tvbs
     go_ty (DAppT t1 t2)          = go_ty t1 <> go_ty t2
     go_ty (DSigT ty ki)          = go_ty ty <> go_ty ki
     go_ty (DVarT n)              = S.singleton n
@@ -1630,9 +1629,9 @@ fvDType = go_ty
     go_pred (DVarPr n)     = S.singleton n
     go_pred _              = S.empty
 
-    go_tvb :: DTyVarBndr -> S.Set Name
-    go_tvb (DPlainTV{})    = S.empty
-    go_tvb (DKindedTV _ k) = go_ty k
+    go_tvb :: DTyVarBndr -> S.Set Name -> S.Set Name
+    go_tvb (DPlainTV n)    fvs = S.delete n fvs
+    go_tvb (DKindedTV n k) fvs = S.delete n fvs <> go_ty k
 
 dtvbName :: DTyVarBndr -> Name
 dtvbName (DPlainTV n)    = n

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -25,6 +25,10 @@ import Control.Monad hiding (forM_, mapM)
 import Control.Monad.Zip
 import Control.Monad.Writer hiding (forM_, mapM)
 import Data.Foldable hiding (notElem)
+import Data.Graph
+import qualified Data.Map as Map
+import Data.Map (Map)
+import qualified Data.Set as Set
 import Data.Traversable
 import Data.Data hiding (Fixity)
 #if __GLASGOW_HASKELL__ > 710
@@ -120,15 +124,15 @@ data NewOrData = Newtype
 
 -- | Corresponds to TH's @Dec@ type.
 data DDec = DLetDec DLetDec
-          | DDataD NewOrData DCxt Name [DTyVarBndr] [DCon] [DDerivClause]
+          | DDataD NewOrData DCxt Name [DTyVarBndr] DKind [DCon] [DDerivClause]
           | DTySynD Name [DTyVarBndr] DType
           | DClassD DCxt Name [DTyVarBndr] [FunDep] [DDec]
           | DInstanceD (Maybe Overlap) DCxt DType [DDec]
           | DForeignD DForeign
           | DOpenTypeFamilyD DTypeFamilyHead
           | DClosedTypeFamilyD DTypeFamilyHead [DTySynEqn]
-          | DDataFamilyD Name [DTyVarBndr]
-          | DDataInstD NewOrData DCxt Name [DType] [DCon] [DDerivClause]
+          | DDataFamilyD Name [DTyVarBndr] DKind
+          | DDataInstD NewOrData DCxt Name [DType] DKind [DCon] [DDerivClause]
           | DTySynInstD Name DTySynEqn
           | DRoleAnnotD Name [Role]
           | DStandaloneDerivD (Maybe DerivStrategy) DCxt DType
@@ -176,9 +180,23 @@ data InjectivityAnn = InjectivityAnn Name [Name]
   deriving (Eq, Ord, Show, Typeable, Data, Generic)
 #endif
 
--- | Corresponds to TH's @Con@ type.
+-- | Corresponds to TH's 'Con' type. Unlike 'Con', all 'DCon's reflect GADT
+-- syntax. This is beneficial for @th-desugar@'s since it means
+-- that all data type declarations can support explicit return kinds, so
+-- one does not need to represent them with something like @'Maybe' 'DKind'@,
+-- since Haskell98-style data declaration syntax isn't used. Accordingly,
+-- there are some differences between 'DCon' and 'Con' to keep in mind:
+--
+-- * Unlike 'ForallC', where the meaning of the 'TyVarBndr's changes depending
+--   on whether it's followed by 'GadtC'/'RecGadtC' or not, the meaning of the
+--   'DTyVarBndr's in a 'DCon' is always the same: it is the list of
+--   universally /and/ existentially quantified type variables. Note that it is
+--   not guaranteed that one set of type variables will appear before the
+--   other.
+--
+-- * A 'DCon' always has an explicit return type.
 data DCon = DCon [DTyVarBndr] DCxt Name DConFields
-                 (Maybe DType)  -- ^ A GADT result type, if there is one
+                 DType  -- ^ The GADT result type
           deriving (Show, Typeable, Data, Generic)
 
 -- | A list of fields either for a standard data constructor or a record
@@ -849,7 +867,7 @@ fixBug8884ForFamilies (DClosedTypeFamilyD (DTypeFamilyHead name tvbs frs ann) eq
       eqns' = map (fixBug8884ForEqn num_args) eqns
   frs' <- remove_arrows num_args frs
   return (DClosedTypeFamilyD (DTypeFamilyHead name tvbs frs' ann) eqns', num_args)
-fixBug8884ForFamilies dec@(DDataFamilyD _ _)
+fixBug8884ForFamilies dec@(DDataFamilyD _ _ _)
   = return (dec, 0)   -- the num_args is ignored for data families
 fixBug8884ForFamilies dec =
   impossible $ "Reifying yielded a FamilyI with a non-family Dec: " ++ show dec
@@ -894,25 +912,33 @@ dsDec d@(FunD {}) = (fmap . map) DLetDec $ dsLetDec d
 dsDec d@(ValD {}) = (fmap . map) DLetDec $ dsLetDec d
 #if __GLASGOW_HASKELL__ > 710
 dsDec (DataD cxt n tvbs mk cons derivings) = do
-  extra_tvbs <- mkExtraTvbs tvbs mk
+  tvbs' <- mapM dsTvb tvbs
+  let data_type = vanillaDataReturnType n tvbs'
   (:[]) <$> (DDataD Data <$> dsCxt cxt <*> pure n
-                         <*> ((++ extra_tvbs) <$> mapM dsTvb tvbs)
-                         <*> concatMapM dsCon cons
+                         <*> mapM dsTvb tvbs <*> maybeDsReturnKind mk
+                         <*> concatMapM (dsCon tvbs' data_type) cons
                          <*> mapM dsDerivClause derivings)
 dsDec (NewtypeD cxt n tvbs mk con derivings) = do
-  extra_tvbs <- mkExtraTvbs tvbs mk
+  tvbs' <- mapM dsTvb tvbs
+  let data_type = vanillaDataReturnType n tvbs'
   (:[]) <$> (DDataD Newtype <$> dsCxt cxt <*> pure n
-                            <*> ((++ extra_tvbs) <$> mapM dsTvb tvbs)
-                            <*> dsCon con
+                            <*> mapM dsTvb tvbs <*> maybeDsReturnKind mk
+                            <*> dsCon tvbs' data_type con
                             <*> mapM dsDerivClause derivings)
 #else
-dsDec (DataD cxt n tvbs cons derivings) =
+dsDec (DataD cxt n tvbs cons derivings) = do
+  tvbs' <- mapM dsTvb tvbs
+  let data_type = vanillaDataReturnType n tvbs'
   (:[]) <$> (DDataD Data <$> dsCxt cxt <*> pure n
-                         <*> mapM dsTvb tvbs <*> concatMapM dsCon cons
+                         <*> pure tvbs' <*> pure typeKind
+                         <*> concatMapM (dsCon tvbs' data_type) cons
                          <*> mapM dsDerivClause derivings)
-dsDec (NewtypeD cxt n tvbs con derivings) =
+dsDec (NewtypeD cxt n tvbs con derivings) = do
+  tvbs' <- mapM dsTvb tvbs
+  let data_type = vanillaDataReturnType n tvbs'
   (:[]) <$> (DDataD Newtype <$> dsCxt cxt <*> pure n
-                            <*> mapM dsTvb tvbs <*> dsCon con
+                            <*> pure tvbs' <*> pure typeKind
+                            <*> dsCon tvbs' data_type con
                             <*> mapM dsDerivClause derivings)
 #endif
 dsDec (TySynD n tvbs ty) =
@@ -934,37 +960,48 @@ dsDec d@(PragmaD {}) = (fmap . map) DLetDec $ dsLetDec d
 #if __GLASGOW_HASKELL__ > 710
 dsDec (OpenTypeFamilyD tfHead) =
   (:[]) <$> (DOpenTypeFamilyD <$> dsTypeFamilyHead tfHead)
-dsDec (DataFamilyD n tvbs m_k) = do
-  extra_tvbs <- mkExtraTvbs tvbs m_k
-  (:[]) <$> (DDataFamilyD n <$> ((++ extra_tvbs) <$> mapM dsTvb tvbs))
+dsDec (DataFamilyD n tvbs m_k) =
+  (:[]) <$> (DDataFamilyD n <$> mapM dsTvb tvbs <*> maybeDsReturnKind m_k)
 #else
 dsDec (FamilyD TypeFam n tvbs m_k) = do
   (:[]) <$> (DOpenTypeFamilyD <$> dsTypeFamilyHead n tvbs m_k)
-dsDec (FamilyD DataFam n tvbs m_k) = do
-  extra_tvbs <- mkExtraTvbs tvbs m_k
-  (:[]) <$> (DDataFamilyD n <$> ((++ extra_tvbs) <$> mapM dsTvb tvbs))
+dsDec (FamilyD DataFam n tvbs m_k) =
+  (:[]) <$> (DDataFamilyD n <$> mapM dsTvb tvbs <*> maybeDsReturnKind m_k)
 #endif
 #if __GLASGOW_HASKELL__ > 710
 dsDec (DataInstD cxt n tys mk cons derivings) = do
-  extra_tvbs <- map dTyVarBndrToDType <$> mkExtraTvbs [] mk
+  tys' <- dataFamInstTypes tys mk
+  let tvbs = dataFamInstTvbs tys'
+      fam_inst_type = dataFamInstReturnType n tys'
   (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n
-                             <*> ((++ extra_tvbs) <$> mapM dsType tys)
-                             <*> concatMapM dsCon cons
+                             <*> mapM dsType tys <*> maybeDsReturnKind mk
+                             <*> concatMapM (dsCon tvbs fam_inst_type) cons
                              <*> mapM dsDerivClause derivings)
 dsDec (NewtypeInstD cxt n tys mk con derivings) = do
-  extra_tvbs <- map dTyVarBndrToDType <$> mkExtraTvbs [] mk
+  tys' <- dataFamInstTypes tys mk
+  let tvbs = dataFamInstTvbs tys'
+      fam_inst_type = dataFamInstReturnType n tys'
   (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n
-                                <*> ((++ extra_tvbs) <$> mapM dsType tys)
-                                <*> dsCon con
+                                <*> pure tys' <*> maybeDsReturnKind mk
+                                <*> dsCon tvbs fam_inst_type con
                                 <*> mapM dsDerivClause derivings)
 #else
 dsDec (DataInstD cxt n tys cons derivings) = do
-  (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n <*> mapM dsType tys
-                             <*> concatMapM dsCon cons
+  tys' <- dataFamInstTypes tys Nothing
+  let tvbs = dataFamInstTvbs tys'
+      fam_inst_type = dataFamInstReturnType n tys'
+  (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n
+                             <*> pure tys' <*> pure typeKind
+                             <*> concatMapM (dsCon tvbs fam_inst_type) cons
                              <*> mapM dsDerivClause derivings)
 dsDec (NewtypeInstD cxt n tys con derivings) = do
-  (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n <*> mapM dsType tys
-                                <*> dsCon con <*> mapM dsDerivClause derivings)
+  tys' <- dataFamInstTypes tys Nothing
+  let tvbs = dataFamInstTvbs tys'
+      fam_inst_type = dataFamInstReturnType n tys'
+  (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n
+                                <*> pure tys' <*> pure typeKind
+                                <*> dsCon tvbs fam_inst_type con
+                                <*> mapM dsDerivClause derivings)
 #endif
 #if __GLASGOW_HASKELL__ < 707
 dsDec (TySynInstD n lhs rhs) = (:[]) <$> (DTySynInstD n <$>
@@ -1001,35 +1038,18 @@ dsDec (StandaloneDerivD cxt ty) =
 dsDec (DefaultSigD n ty) = (:[]) <$> (DDefaultSigD n <$> dsType ty)
 #endif
 
-mkExtraTvbs :: DsMonad q => [TyVarBndr] -> Maybe Kind -> q [DTyVarBndr]
-mkExtraTvbs _         Nothing = return []
-mkExtraTvbs orig_tvbs (Just k) = do
-  k' <- runQ (expandSyns k)  -- just in case
-  dk <- dsType k'
-  let args = split_funs [] dk
-      -- christiaanb: I have no idea how GHC normally picks fresh
-      -- tyvars, this looks like something GHC might do. Though probably in a
-      -- nicer/safer way.
-      --
-      -- RAE: It's actually not terribly far off from what GHC does. This is
-      -- terrible. But I don't see another way to do this. <shudder>
-      --
-      -- All of this is needed so that "dec test 9" passes.
-      orig_names = map (nameBase . tvbName) orig_tvbs
-      all_names  =
-#if __GLASGOW_HASKELL__ <= 708
-                    map ('$':) $
-#endif
-                    take (length args + length orig_tvbs)
-                        (map (:[]) ['a' .. 'z'] ++
-                         concatMap (zipWith (:) ['a' .. 'z'] . repeat . show)
-                                   [(0::Int)..])
-      new_names  = filter (`notElem` orig_names) all_names
-  names <- zipWithM (\n _ -> qNewName n) new_names args
+-- Like mkExtraDKindBinders, but accepts a Maybe Kind
+-- argument instead of DKind.
+mkExtraKindBinders :: DsMonad q => Maybe Kind -> q [DTyVarBndr]
+mkExtraKindBinders =
+  maybe (return typeKind) (runQ . expandSyns >=> dsType) >=> mkExtraDKindBinders'
+
+-- | Like mkExtraDKindBinders, but assumes kind synonyms have been expanded.
+mkExtraDKindBinders' :: Quasi q => DKind -> q [DTyVarBndr]
+mkExtraDKindBinders' k = do
+  let (_, _, args, _) = unravel k
+  names <- replicateM (length args) (qNewName "a")
   return (zipWith DKindedTV names args)
-  where
-    split_funs args (DAppT (DAppT DArrowT arg) res) = split_funs (arg:args) res
-    split_funs args _other                          = reverse args
 
 #if __GLASGOW_HASKELL__ > 710
 -- | Desugar a @FamilyResultSig@
@@ -1082,24 +1102,72 @@ dsLetDec (PragmaD prag) = (:[]) <$> (DPragmaD <$> dsPragma prag)
 dsLetDec _dec = impossible "Illegal declaration in let expression."
 
 -- | Desugar a single @Con@.
+--
+-- Because we always desugar @Con@s to GADT syntax (see the documentation for
+-- 'DCon'), it is not always possible to desugar with just a 'Con' alone.
+-- For instance, we must desugar:
+--
+-- @
+-- data Foo a = forall b. MkFoo b
+-- @
+--
+-- To this:
+--
+-- @
+-- data Foo a :: Type where
+--   MkFoo :: forall a b. b -> Foo a
+-- @
+--
+-- If our only argument was @forall b. MkFoo b@, it would be somewhat awkward
+-- to figure out (1) what the set of universally quantified type variables
+-- (@[a]@) was, and (2) what the return type (@Foo a@) was. For this reason,
+-- we require passing these as arguments. (If we desugar an actual GADT
+-- constructor, these arguments are ignored.)
 dsCon :: DsMonad q
-      => Con -> q [DCon]
-dsCon (NormalC n stys) =
-  (:[]) <$> (DCon [] [] n <$> (DNormalC False <$> mapM dsBangType stys) <*> pure Nothing)
-dsCon (RecC n vstys) =
-  (:[]) <$> (DCon [] [] n <$> (DRecC <$> mapM dsVarBangType vstys) <*> pure Nothing)
-dsCon (InfixC sty1 n sty2) = do
+      => [DTyVarBndr] -- ^ The universally quantified type variables
+                      --   (used if desugaring a non-GADT constructor).
+      -> DType        -- ^ The original data declarations' type
+                      --   (used if desugaring a non-GADT constructor).
+      -> Con -> q [DCon]
+dsCon univ_dtvbs data_type con = do
+  dcons' <- dsCon' con
+  return $ flip map dcons' $ \(n, dtvbs, dcxt, fields, m_gadt_type) ->
+    case m_gadt_type of
+      Nothing ->
+        let ex_dtvbs = dtvbs in
+        DCon (univ_dtvbs ++ ex_dtvbs) dcxt n fields data_type
+      Just gadt_type ->
+        let univ_ex_dtvbs = dtvbs in
+        DCon univ_ex_dtvbs dcxt n fields gadt_type
+
+-- Desugar a Con in isolation. The meaning of the returned DTyVarBndrs changes
+-- depending on what the returned Maybe DType value is:
+--
+-- * If returning Just gadt_ty, then we've encountered a GadtC or RecGadtC,
+--   so the returned DTyVarBndrs are both the universally and existentially
+--   quantified tyvars.
+-- * If returning Nothing, we're dealing with a non-GADT constructor, so
+--   the returned DTyVarBndrs are the existentials only.
+dsCon' :: DsMonad q
+       => Con -> q [(Name, [DTyVarBndr], DCxt, DConFields, Maybe DType)]
+dsCon' (NormalC n stys) = do
+  dtys <- mapM dsBangType stys
+  return [(n, [], [], DNormalC False dtys, Nothing)]
+dsCon' (RecC n vstys) = do
+  vdtys <- mapM dsVarBangType vstys
+  return [(n, [], [], DRecC vdtys, Nothing)]
+dsCon' (InfixC sty1 n sty2) = do
   dty1 <- dsBangType sty1
   dty2 <- dsBangType sty2
-  return $ [DCon [] [] n (DNormalC True [dty1, dty2]) Nothing]
-dsCon (ForallC tvbs cxt con) = do
+  return [(n, [], [], DNormalC True [dty1, dty2], Nothing)]
+dsCon' (ForallC tvbs cxt con) = do
   dtvbs <- mapM dsTvb tvbs
   dcxt <- dsCxt cxt
-  dcons <- dsCon con
-  return $ flip map dcons $ \(DCon dtvbs' dcxt' n fields m_kind) ->
-    DCon (dtvbs ++ dtvbs') (dcxt ++ dcxt') n fields m_kind
+  dcons' <- dsCon' con
+  return $ flip map dcons' $ \(n, dtvbs', dcxt', fields, m_gadt_type) ->
+    (n, dtvbs ++ dtvbs', dcxt ++ dcxt', fields, m_gadt_type)
 #if __GLASGOW_HASKELL__ > 710
-dsCon (GadtC nms btys rty) = do
+dsCon' (GadtC nms btys rty) = do
   dbtys <- mapM dsBangType btys
   drty  <- dsType rty
   sequence $ flip map nms $ \nm -> do
@@ -1111,12 +1179,12 @@ dsCon (GadtC nms btys rty) = do
                 || length dbtys == 2            -- 2. It has exactly two fields
                 || isJust mbFi                  -- 3. It has a programmer-specified
                                                 --    fixity declaration
-    return $ DCon [] [] nm (DNormalC decInfix dbtys) (Just drty)
-dsCon (RecGadtC nms vbtys rty) = do
+    return (nm, [], [], DNormalC decInfix dbtys, Just drty)
+dsCon' (RecGadtC nms vbtys rty) = do
   dvbtys <- mapM dsVarBangType vbtys
   drty   <- dsType rty
   return $ flip map nms $ \nm ->
-    DCon [] [] nm (DRecC dvbtys) (Just drty)
+    (nm, [], [], DRecC dvbtys, Just drty)
 #endif
 
 #if __GLASGOW_HASKELL__ > 710
@@ -1437,3 +1505,141 @@ dTypeToDPred (DConT n)       = return $ DConPr n
 dTypeToDPred DArrowT         = impossible "Arrow used as head of constraint"
 dTypeToDPred (DLitT _)       = impossible "Type literal used as head of constraint"
 dTypeToDPred DWildCardT      = return DWildCardPr
+
+typeKind :: DKind
+typeKind = DConT typeKindName
+
+maybeDsReturnKind :: DsMonad q => Maybe Kind -> q DKind
+maybeDsReturnKind = maybe (return typeKind) dsType
+
+-- Take a vanilla (i.e., non–data-family-instance) data type name and
+-- apply it to its type variable binders to form a DType.
+vanillaDataReturnType :: Name -> [DTyVarBndr] -> DType
+vanillaDataReturnType con_name = applyDType (DConT con_name) . map dTyVarBndrToDType
+
+-- Take a data family name and apply it to its argument types to form a
+-- data family instance DType.
+dataFamInstReturnType :: Name -> [DType] -> DType
+dataFamInstReturnType fam_name = applyDType (DConT fam_name)
+
+-- Take a data family instance of the form @Foo a :: k -> Type -> Type@ and
+-- return @Foo a (b :: k) (c :: Type)@, where @b@ and @c@ are fresh type
+-- variable names.
+dataFamInstTypes :: DsMonad q => [Type] -> Maybe Kind -> q [DType]
+dataFamInstTypes tys mk = do
+  tys' <- mapM dsType tys
+  extra_tvbs <- mkExtraKindBinders mk
+  return $ tys' ++ map dTyVarBndrToDType extra_tvbs
+
+-- Unlike vanilla data types and data family declarations, data family
+-- instance declarations do not come equipped with a list of bound type
+-- variables (at least not yet—see Trace #14268). This means that we have
+-- to reverse engineer this information ourselves from the list of type
+-- patterns. We accomplish this by taking the free variables of the types
+-- and performing a reverse topological sort on them to ensure that the
+-- returned list is well scoped.
+dataFamInstTvbs :: [DType] -> [DTyVarBndr]
+dataFamInstTvbs = toposortTyVarsOf
+
+-- | Take a list of 'DType's, find their free variables, and sort them in
+-- reverse topological order to ensure that they are well scoped.
+--
+-- On older GHCs, this takes measures to avoid returning explicitly bound
+-- kind variables, which was not possible before @TypeInType@.
+toposortTyVarsOf :: [DType] -> [DTyVarBndr]
+toposortTyVarsOf tys =
+  let fvs :: [Name]
+      fvs = Set.toList $ foldMap fvDType tys
+
+      varKindSigs :: Map Name DKind
+      varKindSigs = foldMap go tys
+        where
+          go :: DType -> Map Name DKind
+          go (DForallT {}) = error "`forall` type used in type family pattern"
+          go (DAppT t1 t2) = go t1 `mappend` go t2
+          go (DSigT t k) =
+            let kSigs = go k
+            in case t of
+                 DVarT n -> Map.insert n k kSigs
+                 _       -> go t `mappend` kSigs
+          go (DVarT {}) = mempty
+          go (DConT {}) = mempty
+          go DArrowT    = mempty
+          go (DLitT {}) = mempty
+          go DWildCardT = mempty
+
+      (g, gLookup, _)
+        = graphFromEdges [ (fv, fv, kindVars)
+                         | fv <- fvs
+                         , let kindVars =
+                                 case Map.lookup fv varKindSigs of
+                                   Nothing -> []
+                                   Just ks -> Set.toList (fvDType ks)
+                         ]
+      tg = reverse $ topSort g
+
+      lookupVertex x =
+        case gLookup x of
+          (n, _, _) -> n
+
+      ascribeWithKind n
+        | Just k <- Map.lookup n varKindSigs
+        = DKindedTV n k
+        | otherwise
+        = DPlainTV n
+
+      -- An annoying wrinkle: GHCs before 8.0 don't support explicitly
+      -- quantifying kinds, so something like @forall k (a :: k)@ would be
+      -- rejected. To work around this, we filter out any binders whose names
+      -- also appear in a kind on old GHCs.
+      isKindBinderOnOldGHCs
+#if __GLASGOW_HASKELL__ >= 800
+        = const False
+#else
+        = (`elem` kindVars)
+          where
+            kindVars = foldMap fvDType $ Map.elems varKindSigs
+#endif
+
+  in map ascribeWithKind $
+     filter (not . isKindBinderOnOldGHCs) $
+     map lookupVertex tg
+
+fvDType :: DType -> S.Set Name
+fvDType = go_ty
+  where
+    go_ty :: DType -> S.Set Name
+    go_ty (DForallT tvbs cxt ty) = (foldMap go_tvb tvbs <> go_ty ty <> foldMap go_pred cxt)
+                                   S.\\ S.fromList (map dtvbName tvbs)
+    go_ty (DAppT t1 t2)          = go_ty t1 <> go_ty t2
+    go_ty (DSigT ty ki)          = go_ty ty <> go_ty ki
+    go_ty (DVarT n)              = S.singleton n
+    go_ty (DConT {})             = S.empty
+    go_ty DArrowT                = S.empty
+    go_ty (DLitT {})             = S.empty
+    go_ty DWildCardT             = S.empty
+
+    go_pred :: DPred -> S.Set Name
+    go_pred (DAppPr pr ty) = go_pred pr <> go_ty ty
+    go_pred (DSigPr pr ki) = go_pred pr <> go_ty ki
+    go_pred (DVarPr n)     = S.singleton n
+    go_pred _              = S.empty
+
+    go_tvb :: DTyVarBndr -> S.Set Name
+    go_tvb (DPlainTV{})    = S.empty
+    go_tvb (DKindedTV _ k) = go_ty k
+
+dtvbName :: DTyVarBndr -> Name
+dtvbName (DPlainTV n)    = n
+dtvbName (DKindedTV n _) = n
+
+-- | Decompose a function type into its type variables, its context, its
+-- argument types, and its result type.
+unravel :: DType -> ([DTyVarBndr], [DPred], [DType], DType)
+unravel (DForallT tvbs cxt ty) =
+  let (tvbs', cxt', tys, res) = unravel ty in
+  (tvbs ++ tvbs', cxt ++ cxt', tys, res)
+unravel (DAppT (DAppT DArrowT t1) t2) =
+  let (tvbs, cxt, tys, res) = unravel t2 in
+  (tvbs, cxt, t1 : tys, res)
+unravel t = ([], [], [], t)

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -330,9 +330,9 @@ mkDataConCase var case_alts = do
       Just (DTyConI tycon_dec _) <- dsReify ty_name
       return $ S.fromList $ map get_con_name $ get_cons tycon_dec
 
-    get_cons (DDataD _ _ _ _ cons _)     = cons
-    get_cons (DDataInstD _ _ _ _ cons _) = cons
-    get_cons _                           = []
+    get_cons (DDataD _ _ _ _ _ cons _)     = cons
+    get_cons (DDataInstD _ _ _ _ _ cons _) = cons
+    get_cons _                             = []
 
     get_con_name (DCon _ _ n _ _) = n
 

--- a/Language/Haskell/TH/Desugar/Subst.hs
+++ b/Language/Haskell/TH/Desugar/Subst.hs
@@ -17,7 +17,7 @@ module Language.Haskell.TH.Desugar.Subst (
   DSubst,
 
   -- * Capture-avoiding substitution
-  substTy, unionSubsts, unionMaybeSubsts,
+  substTy, substTyVarBndrs, unionSubsts, unionMaybeSubsts,
 
   -- * Matching a type template against a type
   IgnoreKinds(..), matchTy
@@ -59,8 +59,8 @@ substTy vars (DVarT n)
 substTy _ ty = return ty
 
 substTyVarBndrs :: Quasi q => DSubst -> [DTyVarBndr]
-                -> (DSubst -> [DTyVarBndr] -> q DType)
-                -> q DType
+                -> (DSubst -> [DTyVarBndr] -> q a)
+                -> q a
 substTyVarBndrs vars tvbs thing = do
   (vars', tvbs') <- mapAccumLM substTvb vars tvbs
   thing vars' tvbs'

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -75,7 +75,7 @@ $(dsDecSplice S.dectest15)
 #endif
 
 $(do decs <- S.rec_sel_test
-     [DDataD nd [] name [DPlainTV tvbName] cons []] <- dsDecs decs
+     [DDataD nd [] name [DPlainTV tvbName] k cons []] <- dsDecs decs
      let arg_ty = (DConT name) `DAppT` (DVarT tvbName)
      recsels <- getRecordSelectors arg_ty cons
      let num_sels = length recsels `div` 2 -- ignore type sigs
@@ -89,5 +89,5 @@ $(do decs <- S.rec_sel_test
                fields' = zip stricts types
            in
            DCon tvbs cxt con_name (DNormalC False fields') rty
-         plaindata = [DDataD nd [] name [DPlainTV tvbName] (map unrecord cons) []]
+         plaindata = [DDataD nd [] name [DPlainTV tvbName] k (map unrecord cons) []]
      return (decsToTH plaindata ++ mapMaybe letDecToTH recsels))


### PR DESCRIPTION
At long last, this pemits data type declarations in `DDec` to have explicit return kinds without having lots of fiddly `Maybe`s everywhere. Among other benefits, this should make it easier to control CUSK behavior in generated datatypes in `singletons`.

This is a pretty large patch, so here are some highlights:

1. The `DDataD`, `DDataFamilyD`, and `DDataFamInstD` constructors of `DDec` now have `DKind` fields corresponding to explicit return kinds (if desugaring a non-GADT, this defaults to just `Type`). The `DCon` constructor now has a `DType` field instead of `Maybe DType`, since _all_ constructors now have a GADT return type.

2. The `dsCon` function had to be revamped to desugar everything into GADT syntax. Of particular note is when desugaring a _non_-GADT, we have to know what the universally quantified type variables and return type will be, which isn't information that's easily accessible from having just a `Con`. To compensate for this, I've added extra arguments to `dsCon`.

   A consequence of this is that I had to remove the `instance Desugar [Con] [DCon]`, since the `Desugar` interface doesn't give enough information to invoke `dsCon` any more. This is a bit sad, but not entirely unprecedented (after all, there's no `instance Desugar [Pat] [DPat]` instance either, since `dsPat` also has an unorthodox type signature).

3. I added a `conExistentialTvbs` function which has a "dumb-but-predictable" (to steal a phrase of yours, @goldfirere) way to determine the existentially quantified type variables of a constructor. I added lots of documentation to explain the subtleties of this function, reflecting the discussion in https://github.com/goldfirere/th-desugar/issues/68#issuecomment-328913807.

4. Coming up with explicit type variable binders for data family instances is annoying. Like, really annoying—https://github.com/ghc-proposals/ghc-proposals/pull/55 can't come soon enough. To work around this, I have to reverse engineer the type variables in a data family instance and sort them in reverse topological order to emulate what GHC is doing behind the scenes. The `toposortTyVarsOf` function is what accomplishes this.

5. Surprisingly, I didn't have to change the test suite as much as I though! The `Sweeten` module does a darn good job of turning data types back into forms that old GHCs can understand, so even though I did change the  data types in the `dectest` series to use GADT syntax, old GHCs were perfectly capable of handling them.

   There was one small hiccup in porting `imp_inst_test2` and `imp_inst_test3` over to GADT syntax—due to an (apparently undiagnosed) Template Haskell bug on GHC 7.10 and earlier, GHC would simply reject them if written in GADT syntax. I couldn't find a way to work around this, so I simply hacked around the issue with CPP, writing them in non-GADT syntax on older GHCs.

6. Since we now preserve explicit data type return kinds when desugaring, we no longer need to mimic GHC's gensym behavior to make the `dectest`s pass. This means that `mkExtraDKindBinders` (what used to be called `mkExtraTvbs`) can now be drastically simplified to just use `newName`. Thus, this patch fixes #73.

Along the way, I also added some functions which I needed when porting `singletons` over to accommodate these changes. I'll post the accompanying `singletons` patch shortly. **Edit**: At https://github.com/goldfirere/singletons/pull/305.

Fixes #68.