### PR TITLE
Work around Trac #14843 when sweetening

### DIFF
--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -366,10 +366,11 @@ tyconToTH n
   | n == '(:)                   = PromotedConsT
   | Just deg <- tupleNameDegree_maybe n
                                 = if isDataName n
-                                  then PromotedT n
-                                         -- Ideally, we would sweeten to
-                                         -- PromotedTupleT deg, but we avoid this
-                                         -- for the time being due to #14843.
+#if __GLASGOW_HASKELL__ >= 805
+                                  then PromotedTupleT deg
+#else
+                                  then PromotedT n -- Work around Trac #14843
+#endif
                                   else TupleT deg
   | Just deg <- unboxedTupleNameDegree_maybe n = UnboxedTupleT deg
 #if __GLASGOW_HASKELL__ == 706

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -364,9 +364,13 @@ tyconToTH n
 #endif
   | n == '[]                    = PromotedNilT
   | n == '(:)                   = PromotedConsT
-  | Just deg <- tupleNameDegree_maybe n        = if isDataName n
-                                                 then PromotedTupleT deg
-                                                 else TupleT deg
+  | Just deg <- tupleNameDegree_maybe n
+                                = if isDataName n
+                                  then PromotedT n
+                                         -- Ideally, we would sweeten to
+                                         -- PromotedTupleT deg, but we avoid this
+                                         -- for the time being due to #14843.
+                                  else TupleT deg
   | Just deg <- unboxedTupleNameDegree_maybe n = UnboxedTupleT deg
 #if __GLASGOW_HASKELL__ == 706
     -- Work around Trac #7667


### PR DESCRIPTION
Due to [Trac #14843](https://ghc.haskell.org/trac/ghc/ticket/14843), splicing in any partially applied `PromotedTupleT` will result in an error. This is quite [inconvenient for `singletons`](https://github.com/goldfirere/singletons/issues/252#issuecomment-367904871), since whenever it attempts to splice any declarations, it must first go through `Language.Haskell.TH.Desugar.Sweeten`, which produced `PromotedTupleT`s.

`PromotedT` does not suffer from this bug, so for the time being, let's just sweeten promoted tuple data constructors to `PromotedT deg`. Then, when Trac #14843 is fixed upstream, we can sweeten it back to `PromotedTupleT` on recent GHCs.