### PR TITLE
Fix #76 by using reifyWithLocals when desugaring record pattern-matches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@ Version 1.9
 * Add a `mkDLamEFromDPats` function for constructing a `DLamE` expression using
   a list of `DPat` arguments and a `DExp` body.
 
+* `getDataD`, `dataConNameToDataName`, and `dataConNameToCon` from
+  `Language.Haskell.TH.Desugar.Reify` now look up local declarations. As a
+  result, the contexts in their type signatures have been strengthened from
+  `Quasi` to `DsMonad`.
+
 * Previously, `th-desugar` would silently accept illegal uses of record
   construction with fields that did not belong to the constructor, such as
   `Identity { notAField = "wat" }`. This is now an error.

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -92,12 +92,12 @@ reifyFail name =
 ---------------------------------
 
 -- | Extract the @TyVarBndr@s and constructors given the @Name@ of a type
-getDataD :: Quasi q
+getDataD :: DsMonad q
          => String       -- ^ Print this out on failure
          -> Name         -- ^ Name of the datatype (@data@ or @newtype@) of interest
          -> q ([TyVarBndr], [Con])
 getDataD err name = do
-  info <- reifyWithWarning name
+  info <- reifyWithLocals name
   dec <- case info of
            TyConI dec -> return dec
            _ -> badDeclaration
@@ -116,9 +116,9 @@ getDataD err name = do
 
 -- | From the name of a data constructor, retrive the datatype definition it
 -- is a part of.
-dataConNameToDataName :: Quasi q => Name -> q Name
+dataConNameToDataName :: DsMonad q => Name -> q Name
 dataConNameToDataName con_name = do
-  info <- reifyWithWarning con_name
+  info <- reifyWithLocals con_name
   case info of
 #if __GLASGOW_HASKELL__ > 710
     DataConI _name _type parent_name -> return parent_name
@@ -129,7 +129,7 @@ dataConNameToDataName con_name = do
                 "a data constructor."
 
 -- | From the name of a data constructor, retrieve its definition as a @Con@
-dataConNameToCon :: Quasi q => Name -> q Con
+dataConNameToCon :: DsMonad q => Name -> q Con
 dataConNameToCon con_name = do
   -- we need to get the field ordering from the constructor. We must reify
   -- the constructor to get the tycon, and then reify the tycon to get the `Con`s

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -485,6 +485,11 @@ reifyDecs = [d|
     r22 :: a -> a
     r22 = id   -- test #32
 
+  data R23 a = MkR23 { getR23 :: a }
+
+  r23Test :: R23 a -> a
+  r23Test (MkR23 { getR23 = x }) = x
+
 #if __GLASGOW_HASKELL__ >= 801
   pattern Point :: Int -> Int -> (Int, Int)
   pattern Point{x, y} = (x, y)


### PR DESCRIPTION
When desugaring record pattern-matches, `th-desugar` invokes [`dataConNameToCon`](https://github.com/goldfirere/th-desugar/blob/9063921a2df46a4add1463deac81eb01298a6a65/Language/Haskell/TH/Desugar/Reify.hs#L132), which in turn calls functions that use `reifyWithWarning`. But `reifyWithWarning` is not aware of local declarations, so it fails to look up the locally defined constructors, such as the one found in the program in https://github.com/goldfirere/th-desugar/issues/76#issue-302100796.

This fixes the problem by replacing these uses of `reifyWithWarning` with `reifyWithLocals`.