### PR TITLE
Add support for DerivingVia and QuantifiedConstraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,14 @@
 
 Version 1.9
 -----------
+* Suppose GHC 8.6.
+
+* Add support for `DerivingVia`. Correspondingly, there is now a
+  `DDerivStrategy` data type.
+
+* Add support for `QuantifiedConstraints`. Correspondingly, there is now a
+  `DForallPr` constructor in `DPred` to represent quantified constraint types.
+
 * Remove the `DStarT` constructor of `DType` in favor of `DConT ''Type`.
   Two utility functions have been added to `Language.Haskell.TH.Desugar` to
   ease this transition:

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -25,7 +25,7 @@ module Language.Haskell.TH.Desugar (
   -- * Desugared data types
   DExp(..), DLetDec(..), DPat(..), DType(..), DKind, DCxt, DPred(..),
   DTyVarBndr(..), DMatch(..), DClause(..), DDec(..),
-  DDerivClause(..), DerivStrategy(..), DPatSynDir(..), DPatSynType,
+  DDerivClause(..), DDerivStrategy(..), DPatSynDir(..), DPatSynType,
   Overlap(..), PatSynArgs(..), NewOrData(..),
   DTypeFamilyHead(..), DFamilyResultSig(..), InjectivityAnn(..),
   DCon(..), DConFields(..), DDeclaredInfix, DBangType, DVarBangType,

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -57,7 +57,8 @@ type DKind = DType
 type DCxt = [DPred]
 
 -- | Corresponds to TH's @Pred@
-data DPred = DAppPr DPred DType
+data DPred = DForallPr [DTyVarBndr] DCxt DPred
+           | DAppPr DPred DType
            | DSigPr DPred DKind
            | DVarPr Name
            | DConPr Name
@@ -103,7 +104,7 @@ data DDec = DLetDec DLetDec
           | DDataInstD NewOrData DCxt Name [DType] (Maybe DKind) [DCon] [DDerivClause]
           | DTySynInstD Name DTySynEqn
           | DRoleAnnotD Name [Role]
-          | DStandaloneDerivD (Maybe DerivStrategy) DCxt DType
+          | DStandaloneDerivD (Maybe DDerivStrategy) DCxt DType
           | DDefaultSigD Name DType
           | DPatSynD Name PatSynArgs DPatSynDir DPat
           | DPatSynSigD Name DPatSynType
@@ -293,13 +294,12 @@ data DInfo = DTyConI DDec (Maybe [DInstanceDec])
 type DInstanceDec = DDec -- ^ Guaranteed to be an instance declaration
 
 -- | Corresponds to TH's @DerivClause@ type.
-data DDerivClause = DDerivClause (Maybe DerivStrategy) DCxt
+data DDerivClause = DDerivClause (Maybe DDerivStrategy) DCxt
                   deriving (Show, Typeable, Data, Generic)
 
-#if __GLASGOW_HASKELL__ < 801
--- | Same as @DerivStrategy@ from TH; defined here for backwards compatibility.
-data DerivStrategy = StockStrategy    -- ^ A \"standard\" derived instance
-                   | AnyclassStrategy -- ^ @-XDeriveAnyClass@
-                   | NewtypeStrategy  -- ^ @-XGeneralizedNewtypeDeriving@
-                   deriving (Show, Typeable, Data, Generic)
-#endif
+-- | Corresponds to TH's @DerivStrategy@ type.
+data DDerivStrategy = DStockStrategy     -- ^ A \"standard\" derived instance
+                    | DAnyclassStrategy  -- ^ @-XDeriveAnyClass@
+                    | DNewtypeStrategy   -- ^ @-XGeneralizedNewtypeDeriving@
+                    | DViaStrategy DType -- ^ @-XDerivingVia@
+                    deriving (Show, Typeable, Data, Generic)

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -777,7 +777,7 @@ dsDec (PatSynD n args dir pat) = do
   return [DPatSynD n args dir' pat']
 dsDec (PatSynSigD n ty) = (:[]) <$> (DPatSynSigD n <$> dsType ty)
 dsDec (StandaloneDerivD mds cxt ty) =
-  (:[]) <$> (DStandaloneDerivD mds     <$> dsCxt cxt <*> dsType ty)
+  (:[]) <$> (DStandaloneDerivD <$> mapM dsDerivStrategy mds <*> dsCxt cxt <*> dsType ty)
 #else
 dsDec (StandaloneDerivD cxt ty) =
   (:[]) <$> (DStandaloneDerivD Nothing <$> dsCxt cxt <*> dsType ty)
@@ -1066,13 +1066,25 @@ dsCxt = concatMapM dsPred
 #if __GLASGOW_HASKELL__ >= 801
 -- | Desugar a @DerivClause@.
 dsDerivClause :: DsMonad q => DerivClause -> q DDerivClause
-dsDerivClause (DerivClause mds cxt) = DDerivClause mds <$> dsCxt cxt
+dsDerivClause (DerivClause mds cxt) =
+  DDerivClause <$> mapM dsDerivStrategy mds <*> dsCxt cxt
 #elif __GLASGOW_HASKELL__ >= 711
 dsDerivClause :: DsMonad q => Pred -> q DDerivClause
 dsDerivClause p = DDerivClause Nothing <$> dsPred p
 #else
 dsDerivClause :: DsMonad q => Name -> q DDerivClause
 dsDerivClause n = pure $ DDerivClause Nothing [DConPr n]
+#endif
+
+#if __GLASGOW_HASKELL__ >= 801
+-- | Desugar a @DerivStrategy@.
+dsDerivStrategy :: DsMonad q => DerivStrategy -> q DDerivStrategy
+dsDerivStrategy StockStrategy    = pure DStockStrategy
+dsDerivStrategy AnyclassStrategy = pure DAnyclassStrategy
+dsDerivStrategy NewtypeStrategy  = pure DNewtypeStrategy
+#if __GLASGOW_HASKELL__ >= 805
+dsDerivStrategy (ViaStrategy ty) = DViaStrategy <$> dsType ty
+#endif
 #endif
 
 #if __GLASGOW_HASKELL__ >= 801
@@ -1096,7 +1108,29 @@ dsPred (EqualP t1 t2) = do
 dsPred t
   | Just ts <- splitTuple_maybe t
   = concatMapM dsPred ts
-dsPred t@(ForallT _ _ _) = impossible $ "Forall seen in constraint: " ++ show t
+dsPred (ForallT tvbs cxt p) = do
+  p' <- dsPred p
+  (:[]) <$> (DForallPr <$> mapM dsTvb tvbs <*> dsCxt cxt <*> pure (mkCTupleDPred p'))
+  where
+    -- Make a constraint tuple 'DPred' from a 'DCxt'. Avoids using a 1-tuple.
+    --
+    -- This is all a bit unfortunate, since 'dsPred' goes through the effort of
+    -- flattening constraint tuples in the first place. However, in general it
+    -- is the case that:
+    --
+    -- @forall x. (c x, d x)@
+    --
+    -- Is not equivalent to:
+    --
+    -- @(forall x. c x, forall x. d x)@
+    --
+    -- So in the event that a constraint tuple appears in a quantified
+    -- constraint, we have little choice but to convert it back into a
+    -- constraint tuple after passing through 'dsPred'.
+    mkCTupleDPred :: DCxt -> DPred
+    mkCTupleDPred [pr] = pr
+    mkCTupleDPred prs  = foldl (\f -> DAppPr f . dPredToDType)
+                              (DConPr (tupleDataName (length cxt))) prs
 dsPred (AppT t1 t2) = do
   [p1] <- dsPred t1   -- tuples can't be applied!
   (:[]) <$> DAppPr p1 <$> dsType t2
@@ -1239,9 +1273,10 @@ strictToBang :: Bang -> Bang
 strictToBang = id
 #endif
 
--- | Convert a 'DType' to a 'DPred'
+-- | Convert a 'DType' to a 'DPred'.
 dTypeToDPred :: Monad q => DType -> q DPred
-dTypeToDPred (DForallT _ _ _) = impossible "Forall-type used as constraint"
+dTypeToDPred (DForallT tvbs cxt ty)
+                             = DForallPr tvbs cxt `liftM` dTypeToDPred ty
 dTypeToDPred (DAppT t1 t2)   = liftM2 DAppPr (dTypeToDPred t1) (return t2)
 dTypeToDPred (DSigT ty ki)   = liftM2 DSigPr (dTypeToDPred ty) (return ki)
 dTypeToDPred (DVarT n)       = return $ DVarPr n
@@ -1249,6 +1284,15 @@ dTypeToDPred (DConT n)       = return $ DConPr n
 dTypeToDPred DArrowT         = impossible "Arrow used as head of constraint"
 dTypeToDPred (DLitT _)       = impossible "Type literal used as head of constraint"
 dTypeToDPred DWildCardT      = return DWildCardPr
+
+-- | Convert a 'DPred' to 'DType'.
+dPredToDType :: DPred -> DType
+dPredToDType (DForallPr tvbs cxt p) = DForallT tvbs cxt (dPredToDType p)
+dPredToDType (DAppPr p t)           = DAppT (dPredToDType p) t
+dPredToDType (DSigPr p k)           = DSigT (dPredToDType p) k
+dPredToDType (DVarPr n)             = DVarT n
+dPredToDType (DConPr n)             = DConT n
+dPredToDType DWildCardPr            = DWildCardT
 
 -- Take a data type name (which does not belong to a data family) and
 -- apply it to its type variable binders to form a DType.

--- a/Language/Haskell/TH/Desugar/Expand.hs
+++ b/Language/Haskell/TH/Desugar/Expand.hs
@@ -60,7 +60,7 @@ expand_type ign = go []
   where
     go :: [DType] -> DType -> q DType
     go [] (DForallT tvbs cxt ty) =
-      DForallT tvbs <$> mapM (expand_ ign) cxt <*> expand_type ign ty
+      DForallT tvbs <$> mapM (expand_pred ign) cxt <*> expand_type ign ty
     go _ (DForallT {}) =
       impossible "A forall type is applied to another type."
     go args (DAppT t1 t2) = do
@@ -85,7 +85,7 @@ expand_pred ign = go []
   where
     go :: [DType] -> DPred -> q DPred
     go [] (DForallPr tvbs cxt p) =
-      DForallPr tvbs <$> mapM (expand_ ign) cxt <*> expand_pred ign p
+      DForallPr tvbs <$> mapM (go []) cxt <*> expand_pred ign p
     go _ (DForallPr {}) =
       impossible "A quantified constraint is applied to another constraint."
     go args (DAppPr p t) = do

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -26,7 +26,7 @@ import Language.Haskell.TH.Lift
 $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DPred, ''DTyVarBndr
                  , ''DMatch, ''DClause, ''DLetDec, ''DDec, ''DDerivClause, ''DCon
                  , ''DConFields, ''DForeign, ''DPragma, ''DRuleBndr, ''DTySynEqn
-                 , ''DPatSynDir , ''NewOrData
+                 , ''DPatSynDir , ''NewOrData, ''DDerivStrategy
 #if __GLASGOW_HASKELL__ < 707
                  , ''AnnTarget, ''Role
 #endif
@@ -36,6 +36,6 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DPred, ''DTyVarBndr
                  , ''SourceStrictness, ''Overlap
 #endif
 #if __GLASGOW_HASKELL__ < 801
-                 , ''DerivStrategy, ''PatSynArgs
+                 , ''PatSynArgs
 #endif
                  ])

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -20,6 +20,11 @@ rae@cs.brynmawr.edu
 {-# OPTIONS_GHC -Wno-partial-type-signatures -Wno-redundant-constraints #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+#endif
+
 module Main where
 
 import Prelude hiding ( exp )
@@ -129,6 +134,9 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
              , "over_label" ~: $test46_overloaded_label @=? $(dsSplice test46_overloaded_label)
 #endif
              , "do_partial_match" ~: $test47_do_partial_match @=? $(dsSplice test47_do_partial_match)
+#if __GLASGOW_HASKELL__ >= 805
+             , "quantified_constraints" ~: $test48_quantified_constraints @=? $(dsSplice test48_quantified_constraints)
+#endif
              ]
 
 test35a = $test35_expand

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -26,6 +26,11 @@ rae@cs.brynmawr.edu
 {-# OPTIONS_GHC -Wno-orphans #-}  -- IsLabel is an orphan
 #endif
 
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+#endif
+
 {-# OPTIONS_GHC -fno-warn-missing-signatures -fno-warn-type-defaults
                 -fno-warn-name-shadowing #-}
 
@@ -251,6 +256,13 @@ test46_overloaded_label = [| let p = Point 3 4 in
 #endif
 
 test47_do_partial_match = [| do { Just () <- [Nothing]; return () } |]
+
+#if __GLASGOW_HASKELL__ >= 805
+test48_quantified_constraints =
+  [| let f :: forall f a. (forall x. Eq x => Eq (f x), Eq a) => f a -> f a -> Bool
+         f = (==)
+     in f (Proxy @Int) (Proxy @Int) |]
+#endif
 
 type family TFExpand x
 type instance TFExpand Int = Bool
@@ -535,6 +547,14 @@ reifyDecs = [d|
 
   llEx :: [a] -> Int
   llEx LLMeth = 5
+#endif
+
+#if __GLASGOW_HASKELL__ >= 805
+  newtype Id a = MkId a
+    deriving stock Eq
+
+  newtype R24 a = MkR24 [a]
+    deriving Eq via (Id [a])
 #endif
   |]
 

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -43,7 +43,7 @@ source-repository head
 library
   build-depends:
       base >= 4 && < 5,
-      template-haskell >= 2.8 && < 2.14,
+      template-haskell >= 2.8 && < 2.15,
       containers >= 0.5,
       mtl >= 2.1,
       syb >= 0.4,


### PR DESCRIPTION
Accomplishing this required two notable changes to the AST:

* Instead of reusing `DerivStrategy`, we now have a tailor-made `DDerivStrategy` data type, since the new `DViaStrategy` constructor takes a `DType` as a field.
* The `DPred` data type has a new `DForallPr` constructor for representing quantified constraints.