### PR TITLE
Fix #88

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Version 1.10
   containing quantified constraints.
 * Fix a bug in which `expandType` would not expand type synonyms in the kinds
   of type variable binders in `forall`s.
+* Locally reified class methods, data constructors, and record selectors now
+  quantify kind variables properly.
 * Add more functions which compute free variables.
 
 Version 1.9

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -15,7 +15,7 @@ import Prelude hiding (mapM, foldl, foldr, all, elem, exp, concatMap, and)
 
 import Language.Haskell.TH hiding (match, clause, cxt)
 import Language.Haskell.TH.Syntax hiding (lift)
-import Language.Haskell.TH.ExpandSyns ( expandSyns )
+import Language.Haskell.TH.Datatype ( resolveTypeSynonyms )
 
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
@@ -780,7 +780,8 @@ dsDec (DefaultSigD n ty) = (:[]) <$> (DDefaultSigD n <$> dsType ty)
 -- argument instead of DKind.
 mkExtraKindBinders :: DsMonad q => Maybe Kind -> q [DTyVarBndr]
 mkExtraKindBinders =
-  maybe (pure (DConT typeKindName)) (runQ . expandSyns >=> dsType) >=> mkExtraDKindBinders'
+  maybe (pure (DConT typeKindName)) (runQ . resolveTypeSynonyms >=> dsType)
+    >=> mkExtraDKindBinders'
 
 -- | Like mkExtraDKindBinders, but assumes kind synonyms have been expanded.
 mkExtraDKindBinders' :: Quasi q => DKind -> q [DTyVarBndr]

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -228,7 +228,7 @@ unSigType t = t
 
 -- | Remove all of the explicit kind signatures from a 'Pred'.
 unSigPred :: Pred -> Pred
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 710
 unSigPred = unSigType
 #else
 unSigPred (ClassP n tys) = ClassP n (map unSigType tys)

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -21,18 +21,19 @@ module Language.Haskell.TH.Desugar.Util (
   stripPlainTV_maybe,
   thirdOf3, splitAtList, extractBoundNamesDec,
   extractBoundNamesPat,
-  tvbName, tvbToType, nameMatches, freeNamesOfTypes, thdOf3, firstMatch,
+  tvbToType, tvbToTypeWithSig, nameMatches, thdOf3, firstMatch,
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   tupleDegree_maybe, tupleNameDegree_maybe, unboxedTupleDegree_maybe,
   unboxedTupleNameDegree_maybe, splitTuple_maybe,
   topEverywhereM, isInfixDataCon,
   isTypeKindName, typeKindName,
-  mkExtraKindBindersGeneric, unravelType
+  mkExtraKindBindersGeneric, unravelType, unSigType
   ) where
 
 import Prelude hiding (mapM, foldl, concatMap, any)
 
 import Language.Haskell.TH hiding ( cxt )
+import Language.Haskell.TH.Datatype (tvName)
 import Language.Haskell.TH.Syntax
 
 import Control.Monad ( replicateM )
@@ -107,14 +108,16 @@ stripPlainTV_maybe _           = Nothing
 impossible :: Monad q => String -> q a
 impossible err = fail (err ++ "\n    This should not happen in Haskell.\n    Please email rae@cs.brynmawr.edu with your code if you see this.")
 
--- | Extract a 'Name' from a 'TyVarBndr'
-tvbName :: TyVarBndr -> Name
-tvbName (PlainTV n)    = n
-tvbName (KindedTV n _) = n
-
--- | Convert a 'TyVarBndr' into a 'Type'
+-- | Convert a 'TyVarBndr' into a 'Type', dropping the kind signature
+-- (if it has one).
 tvbToType :: TyVarBndr -> Type
-tvbToType = VarT . tvbName
+tvbToType = VarT . tvName
+
+-- | Convert a 'TyVarBndr' into a 'Type', preserving the kind signature
+-- (if it has one).
+tvbToTypeWithSig :: TyVarBndr -> Type
+tvbToTypeWithSig (PlainTV n)    = VarT n
+tvbToTypeWithSig (KindedTV n k) = SigT (VarT n) k
 
 -- | Do two names name the same thing?
 nameMatches :: Name -> Name -> Bool
@@ -210,6 +213,28 @@ unravelType (AppT (AppT ArrowT t1) t2) =
   (tvbs, cxt, t1 : tys, res)
 unravelType t = ([], [], [], t)
 
+-- | Remove all of the explicit kind signatures from a 'Type'.
+unSigType :: Type -> Type
+unSigType (SigT t _) = t
+unSigType (AppT f x) = AppT (unSigType f) (unSigType x)
+unSigType (ForallT tvbs ctxt t) =
+  ForallT tvbs (map unSigPred ctxt) (unSigType t)
+#if __GLASGOW_HASKELL__ >= 800
+unSigType (InfixT t1 n t2)  = InfixT (unSigType t1) n (unSigType t2)
+unSigType (UInfixT t1 n t2) = UInfixT (unSigType t1) n (unSigType t2)
+unSigType (ParensT t)       = ParensT (unSigType t)
+#endif
+unSigType t = t
+
+-- | Remove all of the explicit kind signatures from a 'Pred'.
+unSigPred :: Pred -> Pred
+#if __GLASGOW_HASKELL__ >= 708
+unSigPred = unSigType
+#else
+unSigPred (ClassP n tys) = ClassP n (map unSigType tys)
+unSigPred (EqualP t1 t2) = EqualP (unSigType t1) (unSigType t2)
+#endif
+
 ----------------------------------------
 -- Free names, etc.
 ----------------------------------------
@@ -259,26 +284,6 @@ extractBoundNamesPat (ViewP _ pat)         = extractBoundNamesPat pat
 #if __GLASGOW_HASKELL__ >= 801
 extractBoundNamesPat (UnboxedSumP pat _ _) = extractBoundNamesPat pat
 #endif
-
-freeNamesOfTypes :: [Type] -> S.Set Name
-freeNamesOfTypes = foldMap go
-  where
-    go (ForallT tvbs cxt ty) = (foldMap go_tvb tvbs <> go ty <> foldMap go_pred cxt)
-                               S.\\ S.fromList (map tvbName tvbs)
-    go (AppT t1 t2)          = go t1 <> go t2
-    go (SigT ty ki)          = go ty <> go ki
-    go (VarT n)              = S.singleton n
-    go _                     = S.empty
-
-#if __GLASGOW_HASKELL__ >= 709
-    go_pred = go
-#else
-    go_pred (ClassP _ tys) = freeNamesOfTypes tys
-    go_pred (EqualP t1 t2) = go t1 <> go t2
-#endif
-
-    go_tvb (PlainTV{})    = S.empty
-    go_tvb (KindedTV _ k) = go k
 
 ----------------------------------------
 -- General utility

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -58,8 +58,6 @@ import qualified Data.Set as S
 import Data.Proxy
 #endif
 
-import Debug.Trace
-
 -- |
 -- Convert a HUnit test suite to a spec.  This can be used to run existing
 -- HUnit tests with Hspec.
@@ -547,7 +545,7 @@ main = hspec $ do
                mapM (\ t -> withLocalDeclarations [] (dsType t >>= expandType >>= return . typeToTH)) >>=
               Syn.lift . map pprint)
 
-    zipWith3M (\a b n -> it ("reifies local definition " ++ show n) $ (if (a == b) then id else traceShow (a, b)) $ a == b)
+    zipWith3M (\a b n -> it ("reifies local definition " ++ show n) $ a == b)
       local_reifications normal_reifications [1..]
 
     zipWithM (\b n -> it ("works on simplCase test " ++ show n) b) simplCase [1..]

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -58,6 +58,8 @@ import qualified Data.Set as S
 import Data.Proxy
 #endif
 
+import Debug.Trace
+
 -- |
 -- Convert a HUnit test suite to a spec.  This can be used to run existing
 -- HUnit tests with Hspec.
@@ -545,7 +547,7 @@ main = hspec $ do
                mapM (\ t -> withLocalDeclarations [] (dsType t >>= expandType >>= return . typeToTH)) >>=
               Syn.lift . map pprint)
 
-    zipWith3M (\a b n -> it ("reifies local definition " ++ show n) $ a == b)
+    zipWith3M (\a b n -> it ("reifies local definition " ++ show n) $ (if (a == b) then id else traceShow (a, b)) $ a == b)
       local_reifications normal_reifications [1..]
 
     zipWithM (\b n -> it ("works on simplCase test " ++ show n) b) simplCase [1..]

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -556,6 +556,13 @@ reifyDecs = [d|
   newtype R24 a = MkR24 [a]
     deriving Eq via (Id [a])
 #endif
+
+#if __GLASGOW_HASKELL__ >= 800
+  class R25 (f :: k -> *) where
+    r26 :: forall (a :: k). f a
+
+  data R27 (a :: k) = R28 { r29 :: Proxy a }
+#endif
   |]
 
 reifyDecsNames :: [Name]
@@ -570,6 +577,9 @@ reifyDecsNames = map mkName
   , "R21"
 #endif
   , "r22"
+#if __GLASGOW_HASKELL__ >= 800
+  , "r26", "R28", "r29"
+#endif
   ]
 
 simplCaseTests :: [Q Exp]

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -47,9 +47,9 @@ library
       containers >= 0.5,
       mtl >= 2.1,
       syb >= 0.4,
+      th-abstraction >= 0.2.10,
       th-lift >= 0.6.1,
-      th-orphans >= 0.9.1,
-      th-expand-syns >= 0.3.0.6
+      th-orphans >= 0.9.1
   default-extensions: TemplateHaskell
   exposed-modules:    Language.Haskell.TH.Desugar,
                       Language.Haskell.TH.Desugar.Sweeten,


### PR DESCRIPTION
This fixes #88 by being more intelligent when locally reifying the types of type class methods, data constructors, and record selectors with poly-kinded types. To accomplish this:

1. We use the [`freeVariablesWellScoped`](http://hackage.haskell.org/package/th-abstraction-0.2.10.0/docs/Language-Haskell-TH-Datatype.html#v:freeVariablesWellScoped) function (from `th-abstraction`) to infer more accurate telescopes in data constructors and record selectors.
2. We use the [`quantifyType`](http://hackage.haskell.org/package/th-abstraction-0.2.10.0/docs/Language-Haskell-TH-Datatype.html#v:quantifyType) function to infer more accurate telescopes for class methods.

This adds a dependency on the `th-abstraction` library (which `th-desugar` was already transitively depending on via `th-lift`). `th-abstraction` already exports a couple of functions that were defined in `Language.Haskell.TH.Desugar.Utils`, such as `tvbName` (`tvName` in `th-abstraction`) and `freeNamesOfTypes` (`freeVariables` in `th-abstraction`), so I was able to remove those. In addition, `th-abstraction` sports a `resolveTypeSynonyms` function, so we are able to remove `th-desugar`'s dependency on `th-expand-syns`.