### PR TITLE
Fix #102 and #103

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,11 @@ Version 1.10
   containing quantified constraints.
 * Fix a bug in which `expandType` would not expand type synonyms in the kinds
   of type variable binders in `forall`s.
+* Fix a bug in which `getRecordSelectors` would omit record selectors from
+  GADT constructors.
 * Locally reified class methods, data constructors, and record selectors now
   quantify kind variables properly.
+* Desugared ADT constructors now quantify kind variables properly.
 * Add more functions which compute free variables.
 
 Version 1.9

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -1309,7 +1309,15 @@ dataFamInstTvbs :: [DType] -> [DTyVarBndr]
 dataFamInstTvbs = toposortTyVarsOf
 
 -- | Take a list of 'DType's, find their free variables, and sort them in
--- reverse topological order to ensure that they are well scoped.
+-- reverse topological order to ensure that they are well scoped. In other
+-- words, the free variables are ordered such that:
+--
+-- 1. Whenever an explicit kind signature of the form @(A :: K)@ is
+--    encountered, the free variables of @K@ will always appear to the left of
+--    the free variables of @A@ in the returned result.
+--
+-- 2. The constraint in (1) notwithstanding, free variables will appear in
+--    left-to-right order of their original appearance.
 --
 -- On older GHCs, this takes measures to avoid returning explicitly bound
 -- kind variables, which was not possible before @TypeInType@.

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -43,12 +43,12 @@ import Data.Generics hiding ( Fixity )
 import Data.Traversable
 import Data.Maybe
 
-#if __GLASGOW_HASKELL__ >= 800
-import qualified Data.Kind as Kind
+#if __GLASGOW_HASKELL__ < 710
+import Data.Monoid
 #endif
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
+#if __GLASGOW_HASKELL__ >= 800
+import qualified Data.Kind as Kind
 #endif
 
 ----------------------------------------

--- a/README.md
+++ b/README.md
@@ -23,3 +23,65 @@ decisions are based on that use case, when more than one design choice was
 possible.
 
 I will try to keep this package up-to-date with respect to changes in GHC.
+
+Known limitations
+-----------------
+`th-desugar` sometimes has to construct types for certain Haskell entities.
+For instance, `th-desugar` desugars all Haskell98-style constructors to use
+GADT syntax, so the following:
+
+```haskell
+data T (a :: k) = MkT (Proxy a)
+```
+
+Will be desugared to something like this:
+
+```haskell
+data T (a :: k) where
+  MkT :: forall k (a :: k). Proxy a -> T (a :: k)
+```
+
+Notice that `k` is explicitly quantified in the type of `MkT`. This is due to
+an additional pass that `th-desugar` performs over the type variable binders
+of `T` to extract all implicitly quantified variables and make them explicit.
+This makes the desugared types forwards-compatible with a
+[future version of GHC](https://github.com/goldfirere/ghc-proposals/blob/bbefbee6fc0cddb10bbacc85f79e66c2706ce13f/proposals/0000-no-kind-vars.rst)
+that requires all kind variables in a top-level `forall` to be explicitly
+quantified.
+
+This process of extracting all implicitly quantified kind variables is not
+perfect, however. There are some obscure programs that will cause `th-desugar`
+to produce type variable binders that are ill scoped. Here is one example:
+
+```haskell
+data P k (a :: k)
+data Foo (a :: Proxy j) (b :: k) c = MkFoo c (P k j)
+```
+
+If you squint hard at `MkFoo`, you'll notice that `j :: k`. However, this
+relationship is not expressed _syntactically_, which means that `th-desugar`
+will not be aware of it. Therefore, `th-desugar` will desugar `Foo` to:
+
+```haskell
+data Foo (a :: Proxy j) (b :: k) c where
+  MkFoo :: forall j k (a :: Proxy j) (b :: k) c.
+           c -> P k j -> Foo (a :: Proxy j) (b :: k) c
+```
+
+This is incorrect since `k` must come before `j` in order to be well scoped.
+There is a workaround to this issue, however: add more explicit kind
+information. If you had instead written this:
+
+```haskell
+data Foo (a :: Proxy (j :: k)) (b :: k) c = MkFoo c (P k j)
+```
+
+Then the fact that `j :: k` is expressed directly in the AST, so `th-desugar`
+is able to pick up on it and pick `forall k j (a :: Proxy j) (b :: k) c. <...>`
+as the telescope for the type of `MkFoo`.
+
+The following constructs are known to be susceptible to this issue:
+
+1. Desugared Haskell98-style constructors
+2. Locally reified class methods
+3. Locally reified record selectors

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -43,6 +43,7 @@ import GHC.TypeLits
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Desugar
+import Language.Haskell.TH.Syntax (Quasi)
 import Data.Generics
 
 #if __GLASGOW_HASKELL__ >= 803
@@ -104,8 +105,8 @@ dropTrailing0s = everywhere (mkT (mkName . frob . nameBase))
 eqTH :: (Data a, Show a) => a -> a -> Bool
 eqTH a b = show (unqualify a) == show (unqualify b)
 
-eqTHSplice :: (Data a, Show a) => a -> a -> Q Exp
-eqTHSplice a b =
+eqTHSplice :: (Quasi q, Data a, Show a) => a -> a -> q Exp
+eqTHSplice a b = runQ $
   if a `eqTH` b
   then [| True |]
   else [| False |]


### PR DESCRIPTION
A two-for-one special.

This fixes #102 by tweaking `getRecordSelectors` to actually use `conExistentialTvbs`, instead of the horribly ad hoc tricks it was using before to detect which type variables are existentially quantified.

This fixes #103 with a simple use of `toposortTyVarsOf`.