### PR TITLE
GHC 8.8 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,7 +51,6 @@ Version 1.10
 * Locally reified class methods, data constructors, and record selectors now
   quantify kind variables properly.
 * Desugared ADT constructors now quantify kind variables properly.
-* Add more functions which compute free variables.
 * Remove `DPred`, as it has become too similar to `DType`. This also means
   that the `DPat` constructors, which previously ended with the suffix `Pa`,
   can now use the suffix `P`, mirroring TH.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,43 @@
 
 Version 1.10
 ------------
+* Support GHC 8.8.
+* Add support for visible kind application, type variable `foralls` in `RULES`,
+  and explicit `forall`s in type family instances. Correspondingly,
+  * There is now a `DAppKindT` constructor in `DType`.
+  * Previously, the `DDataInstD` constructor had fields of type `Name` and
+    `[DType]`. Those have been scrapped in favor of a single field of type
+    `DType`, representing the application of the data family name (which was
+    previously the `Name`) to its arguments (which was previously the
+    `[DType]`).
+
+    `DDataInstD` also has a new field of type `Maybe [DTyVarBndr]` to represent
+    its explicitly quantified type variables (if present).
+  * Previously, the `DTySynEqn` constructor had a field of type `[DType]`.
+    That has been scrapped in favor of a field of type `DType`, representing
+    the application of the type family name (which `DTySynEqn` did not used to
+    contain!) to its arguments (which was previously the `[DType]`).
+
+    `DTySynEqn` also has a new field of type `Maybe [DTyVarBndr]` to represent
+    its explicitly quantified type variables (if present).
+  * `DTySynInstD` no longer has a field of type `Name`, as that is redundant
+    now that each `DTySynEqn` contains the same `Name`.
+  * There is now a field of type `Maybe [DTyVarBndr]` in the `DRuleP`
+    constructor to represent bound type variables in `RULES` (if present).
+* Add support for desugaring implicit params. This does not involve any changes
+  to the `th-desugar` AST, as:
+  * `(?x :: a) => ...` is desugared to `IP "x" a => ...`.
+  * `id ?x` is desugared to `id (ip @"x")`.
+  * `let ?x = 42 in ...` is desugared to
+    `let new_x_val = 42 in bindIP @"x" new_x_val ...` (where `bindIP` is a new
+    utility function exported by `Language.Haskell.TH.Desugar` on GHC 8.0 or
+    later).
+
+  In order to support this desugaring, the type signatures of `dsLetDec` and
+  `dsLetDecs` now return `([DLetDec], DExp -> DExp)` instead of just
+  `[DLetDec]`, where `DExp -> DExp` is the expression which binds the values of
+  implicit params (e.g., `\z -> bindIP @"x" new_x_val z`) if any are bound.
+  (If none are bound, this is simply the `id` function.)
 * Fix a bug in which `toposortTyVarsOf` would error at runtime if given types
   containing `forall`s as arguments.
 * Fix a bug in which `fvDType` would return incorrect results if given a type
@@ -18,6 +55,15 @@ Version 1.10
 * Remove `DPred`, as it has become too similar to `DType`. This also means
   that the `DPat` constructors, which previously ended with the suffix `Pa`,
   can now use the suffix `P`, mirroring TH.
+* The type of `applyDType` has changed from `DType -> [DType] -> DType` to
+  `DType -> [DTypeArg] -> DType`, where `DTypeArg` is a new data type that
+  encodes whether an argument is a normal type argument (e.g., the `Int` in
+  `Maybe Int`) or a visible kind argument (e.g., the `@Type` in
+  `Proxy @Type Char`). A `TypeArg` data type (which is like `DTypeArg`, but
+  with `Type`s/`Kind`s instead of `DType`s/`DKind`s) is also provided.
+
+  A handful of utility functions for manipulating `TypeArg`s and `DTypeArg`s
+  are also exported.
 
 Version 1.9
 -----------

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -53,6 +53,7 @@ module Language.Haskell.TH.Desugar (
 #if __GLASGOW_HASKELL__ >= 801
   dsPatSynDir,
 #endif
+  dsTypeArg,
 
   -- * Converting desugared AST back to TH AST
   module Language.Haskell.TH.Desugar.Sweeten,
@@ -82,7 +83,7 @@ module Language.Haskell.TH.Desugar (
   module Language.Haskell.TH.Desugar.FV,
 
   -- * Utility functions
-  applyDExp, applyDType,
+  applyDExp,
   dPatToDExp, removeWilds,
   getDataD, dataConNameToDataName, dataConNameToCon,
   nameOccursIn, allNamesIn, flattenDValD, getRecordSelectors,
@@ -92,8 +93,17 @@ module Language.Haskell.TH.Desugar (
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   unboxedTupleDegree_maybe, unboxedTupleNameDegree_maybe,
   strictToBang, isTypeKindName, typeKindName,
+#if __GLASGOW_HASKELL__ >= 800
+  bindIP,
+#endif
   unravel, conExistentialTvbs, mkExtraDKindBinders,
   dTyVarBndrToDType, toposortTyVarsOf,
+
+  -- ** 'TypeArg'
+  TypeArg(..), applyType, filterTANormals, unfoldType, unTypeArg,
+
+  -- ** 'DTypeArg'
+  DTypeArg(..), applyDType, filterDTANormals, unfoldDType, unDTypeArg,
 
   -- ** Extracting bound names
   extractBoundNamesStmt, extractBoundNamesDec, extractBoundNamesPat
@@ -144,6 +154,10 @@ instance Desugar TyVarBndr DTyVarBndr where
 instance Desugar [Dec] [DDec] where
   desugar = dsDecs
   sweeten = decsToTH
+
+instance Desugar TypeArg DTypeArg where
+  desugar = dsTypeArg
+  sweeten = typeArgToTH
 
 -- | If the declaration passed in is a 'DValD', creates new, equivalent
 -- declarations such that the 'DPat' in all 'DValD's is just a plain

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -44,7 +44,8 @@ module Language.Haskell.TH.Desugar (
   dsCon, dsForeign, dsPragma, dsRuleBndr,
 
   -- ** Secondary desugaring functions
-  PatM, dsPred, dsPat, dsDec, dsDerivClause, dsLetDec,
+  PatM, dsPred, dsPat, dsDec, dsDataDec, dsDataInstDec,
+  DerivingClause, dsDerivClause, dsLetDec,
   dsMatches, dsBody, dsGuards, dsDoStmts, dsComp, dsClauses,
   dsBangType, dsVarBangType,
 #if __GLASGOW_HASKELL__ > 710
@@ -100,10 +101,10 @@ module Language.Haskell.TH.Desugar (
   dTyVarBndrToDType, toposortTyVarsOf,
 
   -- ** 'TypeArg'
-  TypeArg(..), applyType, filterTANormals, unfoldType, unTypeArg,
+  TypeArg(..), applyType, filterTANormals, unfoldType,
 
   -- ** 'DTypeArg'
-  DTypeArg(..), applyDType, filterDTANormals, unfoldDType, unDTypeArg,
+  DTypeArg(..), applyDType, filterDTANormals, unfoldDType,
 
   -- ** Extracting bound names
   extractBoundNamesStmt, extractBoundNamesDec, extractBoundNamesPat

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -42,6 +42,7 @@ data DPat = DLitP Lit
 -- types and kinds.
 data DType = DForallT [DTyVarBndr] DCxt DType
            | DAppT DType DType
+           | DAppKindT DType DKind
            | DSigT DType DKind
            | DVarT Name
            | DConT Name
@@ -95,8 +96,9 @@ data DDec = DLetDec DLetDec
           | DOpenTypeFamilyD DTypeFamilyHead
           | DClosedTypeFamilyD DTypeFamilyHead [DTySynEqn]
           | DDataFamilyD Name [DTyVarBndr] (Maybe DKind)
-          | DDataInstD NewOrData DCxt Name [DType] (Maybe DKind) [DCon] [DDerivClause]
-          | DTySynInstD Name DTySynEqn
+          | DDataInstD NewOrData DCxt (Maybe [DTyVarBndr]) DType (Maybe DKind)
+                       [DCon] [DDerivClause]
+          | DTySynInstD DTySynEqn
           | DRoleAnnotD Name [Role]
           | DStandaloneDerivD (Maybe DDerivStrategy) DCxt DType
           | DDefaultSigD Name DType
@@ -245,7 +247,7 @@ data DForeign = DImportF Callconv Safety String Name DType
 data DPragma = DInlineP Name Inline RuleMatch Phases
              | DSpecialiseP Name DType (Maybe Inline) Phases
              | DSpecialiseInstP DType
-             | DRuleP String [DRuleBndr] DExp DExp Phases
+             | DRuleP String (Maybe [DTyVarBndr]) [DRuleBndr] DExp DExp Phases
              | DAnnP AnnTarget DExp
              | DLineP Int String
              | DCompleteP [Name] (Maybe Name)
@@ -257,7 +259,7 @@ data DRuleBndr = DRuleVar Name
                deriving (Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @TySynEqn@ type (to store type family equations).
-data DTySynEqn = DTySynEqn [DType] DType
+data DTySynEqn = DTySynEqn (Maybe [DTyVarBndr]) DType DType
                deriving (Show, Typeable, Data, Generic)
 
 #if __GLASGOW_HASKELL__ < 707

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -7,7 +7,8 @@ Desugars full Template Haskell syntax into a smaller core syntax for further
 processing. The desugared types and constructors are prefixed with a D.
 -}
 
-{-# LANGUAGE TemplateHaskell, LambdaCase, CPP, ScopedTypeVariables, TupleSections #-}
+{-# LANGUAGE TemplateHaskell, LambdaCase, CPP, ScopedTypeVariables,
+             TupleSections, DeriveDataTypeable, DeriveGeneric #-}
 
 module Language.Haskell.TH.Desugar.Core where
 
@@ -23,7 +24,8 @@ import Control.Applicative
 import Control.Monad hiding (forM_, mapM)
 import Control.Monad.Zip
 import Control.Monad.Writer hiding (forM_, mapM)
-import Data.Foldable hiding (notElem)
+import Data.Data (Data, Typeable)
+import Data.Foldable hiding (concat, notElem)
 import Data.Graph
 import qualified Data.Map as M
 import Data.Map (Map)
@@ -42,7 +44,12 @@ import qualified Control.Monad.Fail as MonadFail
 import GHC.OverloadedLabels ( fromLabel )
 #endif
 
+#if __GLASGOW_HASKELL__ >= 807
+import GHC.Classes (IP(..))
+#endif
+
 import GHC.Exts
+import GHC.Generics (Generic)
 
 import Language.Haskell.TH.Desugar.AST
 import Language.Haskell.TH.Desugar.FV
@@ -83,7 +90,10 @@ dsExp (CondE e1 e2 e3) =
 dsExp (MultiIfE guarded_exps) =
   let failure = DAppE (DVarE 'error) (DLitE (StringL "Non-exhaustive guards in multi-way if")) in
   dsGuards guarded_exps failure
-dsExp (LetE decs exp) = DLetE <$> dsLetDecs decs <*> dsExp exp
+dsExp (LetE decs exp) = do
+  (decs', ip_binder) <- dsLetDecs decs
+  exp' <- dsExp exp
+  return $ DLetE decs' $ ip_binder exp'
     -- the following special case avoids creating a new "let" when it's not
     -- necessary. See #34.
 dsExp (CaseE (VarE scrutinee) matches) = do
@@ -227,6 +237,10 @@ dsExp (UnboxedSumE exp alt arity) =
 #if __GLASGOW_HASKELL__ >= 803
 dsExp (LabelE str) = return $ DVarE 'fromLabel `DAppTypeE` DLitT (StrTyLit str)
 #endif
+#if __GLASGOW_HASKELL__ >= 807
+dsExp (ImplicitParamVarE n) = return $ DVarE 'ip `DAppTypeE` DLitT (StrTyLit n)
+dsExp (MDoE {}) = fail "th-desugar currently does not support RecursiveDo"
+#endif
 
 -- | Desugar a lambda expression, where the body has already been desugared
 dsLam :: DsMonad q => [Pat] -> DExp -> q DExp
@@ -288,10 +302,14 @@ dsBody :: DsMonad q
        -> [Dec]     -- ^ "where" declarations
        -> DExp      -- ^ what to do if the guards don't match
        -> q DExp
-dsBody (NormalB exp) decs _ =
-  maybeDLetE <$> dsLetDecs decs <*> dsExp exp
-dsBody (GuardedB guarded_exps) decs failure =
-  maybeDLetE <$> dsLetDecs decs <*> dsGuards guarded_exps failure
+dsBody (NormalB exp) decs _ = do
+  (decs', ip_binder) <- dsLetDecs decs
+  exp' <- dsExp exp
+  return $ maybeDLetE decs' $ ip_binder exp'
+dsBody (GuardedB guarded_exps) decs failure = do
+  (decs', ip_binder) <- dsLetDecs decs
+  guarded_exp' <- dsGuards guarded_exps failure
+  return $ maybeDLetE decs' $ ip_binder guarded_exp'
 
 -- | If decs is non-empty, delcare them in a let:
 maybeDLetE :: [DLetDec] -> DExp -> DExp
@@ -329,9 +347,9 @@ dsGuardStmts (BindS pat exp : rest) success failure = do
   exp' <- dsExp exp
   return $ DCaseE exp' [DMatch pat' success'', DMatch DWildP failure]
 dsGuardStmts (LetS decs : rest) success failure = do
-  decs' <- dsLetDecs decs
+  (decs', ip_binder) <- dsLetDecs decs
   success' <- dsGuardStmts rest success failure
-  return $ DLetE decs' success'
+  return $ DLetE decs' $ ip_binder success'
   -- special-case a final pattern containing "otherwise" or "True"
   -- note that GHC does this special-casing, too, in DsGRHSs.isTrueLHsExpr
 dsGuardStmts [NoBindS exp] success _failure
@@ -348,6 +366,9 @@ dsGuardStmts (NoBindS exp : rest) success failure = do
   return $ DCaseE exp' [ DMatch (DConP 'True []) success'
                        , DMatch (DConP 'False []) failure ]
 dsGuardStmts (ParS _ : _) _ _ = impossible "Parallel comprehension in a pattern guard."
+#if __GLASGOW_HASKELL__ >= 807
+dsGuardStmts (RecS {} : _) _ _ = fail "th-desugar currently does not support RecursiveDo"
+#endif
 
 -- | Desugar the @Stmt@s in a @do@ expression
 dsDoStmts :: DsMonad q => [Stmt] -> q DExp
@@ -356,12 +377,18 @@ dsDoStmts [NoBindS exp] = dsExp exp
 dsDoStmts (BindS pat exp : rest) = do
   rest' <- dsDoStmts rest
   dsBindS exp pat rest' "do expression"
-dsDoStmts (LetS decs : rest) = DLetE <$> dsLetDecs decs <*> dsDoStmts rest
+dsDoStmts (LetS decs : rest) = do
+  (decs', ip_binder) <- dsLetDecs decs
+  rest' <- dsDoStmts rest
+  return $ DLetE decs' $ ip_binder rest'
 dsDoStmts (NoBindS exp : rest) = do
   exp' <- dsExp exp
   rest' <- dsDoStmts rest
   return $ DAppE (DAppE (DVarE '(>>)) exp') rest'
 dsDoStmts (ParS _ : _) = impossible "Parallel comprehension in a do-statement."
+#if __GLASGOW_HASKELL__ >= 807
+dsDoStmts (RecS {} : _) = fail "th-desugar currently does not support RecursiveDo"
+#endif
 
 -- | Desugar the @Stmt@s in a list or monad comprehension
 dsComp :: DsMonad q => [Stmt] -> q DExp
@@ -370,7 +397,10 @@ dsComp [NoBindS exp] = DAppE (DVarE 'return) <$> dsExp exp
 dsComp (BindS pat exp : rest) = do
   rest' <- dsComp rest
   dsBindS exp pat rest' "monad comprehension"
-dsComp (LetS decs : rest) = DLetE <$> dsLetDecs decs <*> dsComp rest
+dsComp (LetS decs : rest) = do
+  (decs', ip_binder) <- dsLetDecs decs
+  rest' <- dsComp rest
+  return $ DLetE decs' $ ip_binder rest'
 dsComp (NoBindS exp : rest) = do
   exp' <- dsExp exp
   rest' <- dsComp rest
@@ -379,6 +409,9 @@ dsComp (ParS stmtss : rest) = do
   (pat, exp) <- dsParComp stmtss
   rest' <- dsComp rest
   DAppE (DAppE (DVarE '(>>=)) exp) <$> dsLam [pat] rest'
+#if __GLASGOW_HASKELL__ >= 807
+dsComp (RecS {} : _) = fail "th-desugar currently does not support RecursiveDo"
+#endif
 
 -- Desugar a binding statement in a do- or list comprehension.
 --
@@ -624,15 +657,19 @@ fixBug8884ForFamilies dec = return (dec, 0)   -- return value ignored
 #endif
 
 fixBug8884ForInstances :: Int -> DDec -> DDec
-fixBug8884ForInstances num_args (DTySynInstD name eqn) =
-  DTySynInstD name (fixBug8884ForEqn num_args eqn)
+#if __GLASGOW_HASKELL__ < 708
+fixBug8884ForInstances num_args (DTySynInstD eqn) =
+  DTySynInstD (fixBug8884ForEqn num_args eqn)
+#endif
 fixBug8884ForInstances _ dec = dec
 
 fixBug8884ForEqn :: Int -> DTySynEqn -> DTySynEqn
 #if __GLASGOW_HASKELL__ < 708
-fixBug8884ForEqn num_args (DTySynEqn lhs rhs) =
-  let lhs' = drop (length lhs - num_args) lhs in
-  DTySynEqn lhs' rhs
+fixBug8884ForEqn num_args (DTySynEqn mtvbs lhs rhs) =
+  let (lhs_head, lhs_args) = unfoldDType lhs
+      lhs_args'            = drop (length lhs_args - num_args) lhs_args
+      lhs'                 = applyDType lhs_head lhs_args' in
+  DTySynEqn mtvbs lhs' rhs
 #else
 fixBug8884ForEqn _ = id
 #endif
@@ -643,8 +680,8 @@ dsDecs = concatMapM dsDec
 
 -- | Desugar a single @Dec@, perhaps producing multiple 'DDec's
 dsDec :: DsMonad q => Dec -> q [DDec]
-dsDec d@(FunD {}) = (fmap . map) DLetDec $ dsLetDec d
-dsDec d@(ValD {}) = (fmap . map) DLetDec $ dsLetDec d
+dsDec d@(FunD {}) = fmap (map DLetDec . fst) $ dsLetDec d
+dsDec d@(ValD {}) = fmap (map DLetDec . fst) $ dsLetDec d
 #if __GLASGOW_HASKELL__ > 710
 dsDec (DataD cxt n tvbs mk cons derivings) = do
   tvbs'    <- mapM dsTvb tvbs
@@ -690,10 +727,10 @@ dsDec (InstanceD over cxt ty decs) =
 dsDec (InstanceD cxt ty decs) =
   (:[]) <$> (DInstanceD <$> pure Nothing <*> dsCxt cxt <*> dsType ty <*> dsDecs decs)
 #endif
-dsDec d@(SigD {}) = (fmap . map) DLetDec $ dsLetDec d
+dsDec d@(SigD {}) = fmap (map DLetDec . fst) $ dsLetDec d
 dsDec (ForeignD f) = (:[]) <$> (DForeignD <$> dsForeign f)
-dsDec d@(InfixD {}) = (fmap . map) DLetDec $ dsLetDec d
-dsDec d@(PragmaD {}) = (fmap . map) DLetDec $ dsLetDec d
+dsDec d@(InfixD {}) = fmap (map DLetDec . fst) $ dsLetDec d
+dsDec d@(PragmaD {}) = fmap (map DLetDec . fst) $ dsLetDec d
 #if __GLASGOW_HASKELL__ > 710
 dsDec (OpenTypeFamilyD tfHead) =
   (:[]) <$> (DOpenTypeFamilyD <$> dsTypeFamilyHead tfHead)
@@ -705,57 +742,101 @@ dsDec (FamilyD TypeFam n tvbs m_k) = do
 dsDec (FamilyD DataFam n tvbs m_k) =
   (:[]) <$> (DDataFamilyD n <$> mapM dsTvb tvbs <*> mapM dsType m_k)
 #endif
-#if __GLASGOW_HASKELL__ > 710
+#if __GLASGOW_HASKELL__ >= 807
+dsDec (DataInstD cxt mtvbs lhs mk cons derivings) = do
+  case unfoldType lhs of
+    (ConT n, tys) -> do
+      mtvbs'     <- mapM (mapM dsTvb) mtvbs
+      tys'       <- mapM dsTypeArg tys
+      extra_tvbs <- mkExtraKindBinders mk
+      let lhs'          = applyDType (DConT n) tys'
+          all_tys       = tys' ++ map (DTANormal . dTyVarBndrToDType) extra_tvbs
+          all_tvbs      = case mtvbs' of
+                            Nothing    -> dataFamInstTvbsCompat all_tys
+                            Just tvbs' -> tvbs' ++ extra_tvbs
+          fam_inst_type = dataFamInstReturnType n all_tys
+      (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure mtvbs'
+                                 <*> pure lhs' <*> mapM dsType mk
+                                 <*> concatMapM (dsCon all_tvbs fam_inst_type) cons
+                                 <*> mapM dsDerivClause derivings)
+    (_, _) -> fail $ "Unexpected data instance LHS: " ++ pprint lhs
+dsDec (NewtypeInstD cxt mtvbs lhs mk con derivings) = do
+  case unfoldType lhs of
+    (ConT n, tys) -> do
+      mtvbs'     <- mapM (mapM dsTvb) mtvbs
+      tys'       <- mapM dsTypeArg tys
+      extra_tvbs <- mkExtraKindBinders mk
+      let lhs'          = applyDType (DConT n) tys'
+          all_tys       = tys' ++ map (DTANormal . dTyVarBndrToDType) extra_tvbs
+          all_tvbs      = case mtvbs' of
+                            Nothing    -> dataFamInstTvbsCompat all_tys
+                            Just tvbs' -> tvbs' ++ extra_tvbs
+          fam_inst_type = dataFamInstReturnType n all_tys
+      (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure mtvbs'
+                                    <*> pure lhs' <*> mapM dsType mk
+                                    <*> dsCon all_tvbs fam_inst_type con
+                                    <*> mapM dsDerivClause derivings)
+    (_, _) -> fail $ "Unexpected newtype instance LHS: " ++ pprint lhs
+#elif __GLASGOW_HASKELL__ > 710
 dsDec (DataInstD cxt n tys mk cons derivings) = do
-  tys'    <- mapM dsType tys
-  all_tys <- dataFamInstTypes tys' mk
-  let tvbs = dataFamInstTvbs all_tys
+  tys'    <- mapM (fmap DTANormal . dsType) tys
+  all_tys <- dataFamInstTypeArgs tys' mk
+  let tvbs = dataFamInstTvbsCompat all_tys
       fam_inst_type = dataFamInstReturnType n all_tys
-  (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n
-                             <*> pure tys' <*> mapM dsType mk
+      lhs' = applyDType (DConT n) tys'
+  (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure Nothing
+                             <*> pure lhs' <*> mapM dsType mk
                              <*> concatMapM (dsCon tvbs fam_inst_type) cons
                              <*> mapM dsDerivClause derivings)
 dsDec (NewtypeInstD cxt n tys mk con derivings) = do
-  tys'    <- mapM dsType tys
-  all_tys <- dataFamInstTypes tys' mk
-  let tvbs = dataFamInstTvbs all_tys
+  tys'    <- mapM (fmap DTANormal . dsType) tys
+  all_tys <- dataFamInstTypeArgs tys' mk
+  let tvbs = dataFamInstTvbsCompat all_tys
       fam_inst_type = dataFamInstReturnType n all_tys
-  (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n
-                                <*> pure tys' <*> mapM dsType mk
+      lhs' = applyDType (DConT n) tys'
+  (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure Nothing
+                                <*> pure lhs' <*> mapM dsType mk
                                 <*> dsCon tvbs fam_inst_type con
                                 <*> mapM dsDerivClause derivings)
 #else
 dsDec (DataInstD cxt n tys cons derivings) = do
-  tys' <- mapM dsType tys
-  let tvbs = dataFamInstTvbs tys'
+  tys' <- mapM (fmap DTANormal . dsType) tys
+  let tvbs = dataFamInstTvbsCompat tys'
       fam_inst_type = dataFamInstReturnType n tys'
-  (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure n
-                             <*> pure tys' <*> pure Nothing
+      lhs' = applyDType (DConT n) tys'
+  (:[]) <$> (DDataInstD Data <$> dsCxt cxt <*> pure Nothing
+                             <*> pure lhs' <*> pure Nothing
                              <*> concatMapM (dsCon tvbs fam_inst_type) cons
                              <*> mapM dsDerivClause derivings)
 dsDec (NewtypeInstD cxt n tys con derivings) = do
-  tys' <- mapM dsType tys
-  let tvbs = dataFamInstTvbs tys'
+  tys' <- mapM (fmap DTANormal . dsType) tys
+  let tvbs = dataFamInstTvbsCompat tys'
       fam_inst_type = dataFamInstReturnType n tys'
-  (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure n
-                                <*> pure tys' <*> pure Nothing
+      lhs' = applyDType (DConT n) tys'
+  (:[]) <$> (DDataInstD Newtype <$> dsCxt cxt <*> pure Nothing
+                                <*> pure lhs' <*> pure Nothing
                                 <*> dsCon tvbs fam_inst_type con
                                 <*> mapM dsDerivClause derivings)
 #endif
-#if __GLASGOW_HASKELL__ < 707
-dsDec (TySynInstD n lhs rhs) = (:[]) <$> (DTySynInstD n <$>
-                                          (DTySynEqn <$> mapM dsType lhs
-                                                     <*> dsType rhs))
+#if __GLASGOW_HASKELL__ >= 807
+dsDec (TySynInstD eqn) = (:[]) <$> (DTySynInstD <$> dsTySynEqn (error "Unused") eqn)
+#elif __GLASGOW_HASKELL__ >= 707
+dsDec (TySynInstD n eqn) = (:[]) <$> (DTySynInstD <$> dsTySynEqn n eqn)
 #else
-dsDec (TySynInstD n eqn) = (:[]) <$> (DTySynInstD n <$> dsTySynEqn eqn)
+dsDec (TySynInstD n lhss rhs) = do
+  lhss' <- mapM dsType lhss
+  let lhs' = applyDType (DConT n) $ map DTANormal lhss'
+  (:[]) <$> (DTySynInstD <$> (DTySynEqn Nothing lhs' <$> dsType rhs))
+#endif
+#if __GLASGOW_HASKELL__ >= 707
 #if __GLASGOW_HASKELL__ > 710
 dsDec (ClosedTypeFamilyD tfHead eqns) =
   (:[]) <$> (DClosedTypeFamilyD <$> dsTypeFamilyHead tfHead
-                                <*> mapM dsTySynEqn eqns)
+                                <*> mapM (dsTySynEqn (typeFamilyHeadName tfHead)) eqns)
 #else
 dsDec (ClosedTypeFamilyD n tvbs m_k eqns) = do
   (:[]) <$> (DClosedTypeFamilyD <$> dsTypeFamilyHead n tvbs m_k
-                                <*> mapM dsTySynEqn eqns)
+                                <*> mapM (dsTySynEqn n) eqns)
 #endif
 dsDec (RoleAnnotD n roles) = return [DRoleAnnotD n roles]
 #endif
@@ -775,6 +856,9 @@ dsDec (StandaloneDerivD cxt ty) =
   (:[]) <$> (DStandaloneDerivD Nothing <$> dsCxt cxt <*> dsType ty)
 #endif
 dsDec (DefaultSigD n ty) = (:[]) <$> (DDefaultSigD n <$> dsType ty)
+#endif
+#if __GLASGOW_HASKELL__ >= 807
+dsDec (ImplicitParamBindD {}) = impossible "Non-`let`-bound implicit param binding"
 #endif
 
 -- Like mkExtraDKindBinders, but accepts a Maybe Kind
@@ -801,6 +885,9 @@ dsTypeFamilyHead (TypeFamilyHead n tvbs result inj)
   = DTypeFamilyHead n <$> mapM dsTvb tvbs
                       <*> dsFamilyResultSig result
                       <*> pure inj
+
+typeFamilyHeadName :: TypeFamilyHead -> Name
+typeFamilyHeadName (TypeFamilyHead n _ _ _) = n
 #else
 -- | Desugar bits and pieces into a 'DTypeFamilyHead'
 dsTypeFamilyHead :: DsMonad q
@@ -814,28 +901,78 @@ dsTypeFamilyHead n tvbs m_kind = do
                     <*> pure Nothing
 #endif
 
--- | Desugar @Dec@s that can appear in a let expression
-dsLetDecs :: DsMonad q => [Dec] -> q [DLetDec]
-dsLetDecs = concatMapM dsLetDec
+-- | Desugar @Dec@s that can appear in a @let@ expression.
+dsLetDecs :: DsMonad q => [Dec] -> q ([DLetDec], DExp -> DExp)
+dsLetDecs decs = do
+  (let_decss, ip_binders) <- mapAndUnzipM dsLetDec decs
+  let let_decs :: [DLetDec]
+      let_decs = concat let_decss
 
--- | Desugar a single @Dec@, perhaps producing multiple 'DLetDec's
-dsLetDec :: DsMonad q => Dec -> q [DLetDec]
+      ip_binder :: DExp -> DExp
+      ip_binder = foldr (.) id ip_binders
+  return (let_decs, ip_binder)
+
+-- | Desugar a single 'Dec' that can appear in a @let@ expression.
+-- This produces the following output:
+--
+-- * One or more 'DLetDec's (a single 'Dec' can produce multiple 'DLetDec's
+--   in the event of a value declaration that binds multiple things by way
+--   of pattern matching.
+--
+-- * A function of type @'DExp' -> 'DExp'@, which should be applied to the
+--   expression immediately following the 'DLetDec's. This function prepends
+--   binding forms for any implicit params that were bound in the argument
+--   'Dec'. (If no implicit params are bound, this is simply the 'id'
+--   function.)
+--
+-- For instance, if the argument to 'dsLetDec' is the @?x = 42@ part of this
+-- expression:
+--
+-- @
+-- let { ?x = 42 } in ?x
+-- @
+--
+-- Then the output is:
+--
+-- * @let new_x_val = 42@
+--
+-- * @\\z -> 'bindIP' \@\"x\" new_x_val z@
+--
+-- This way, the expression
+-- @let { new_x_val = 42 } in 'bindIP' \@"x" new_x_val ('ip' \@\"x\")@ can be
+-- formed.
+dsLetDec :: DsMonad q => Dec -> q ([DLetDec], DExp -> DExp)
 dsLetDec (FunD name clauses) = do
   clauses' <- dsClauses name clauses
-  return [DFunD name clauses']
+  return ([DFunD name clauses'], id)
 dsLetDec (ValD pat body where_decs) = do
   (pat', vars) <- dsPatX pat
   body' <- dsBody body where_decs error_exp
   let extras = uncurry (zipWith (DValD . DVarP)) $ unzip vars
-  return $ DValD pat' body' : extras
+  return (DValD pat' body' : extras, id)
   where
     error_exp = DAppE (DVarE 'error) (DLitE
                        (StringL $ "Non-exhaustive patterns for " ++ pprint pat))
 dsLetDec (SigD name ty) = do
   ty' <- dsType ty
-  return [DSigD name ty']
-dsLetDec (InfixD fixity name) = return [DInfixD fixity name]
-dsLetDec (PragmaD prag) = (:[]) <$> (DPragmaD <$> dsPragma prag)
+  return ([DSigD name ty'], id)
+dsLetDec (InfixD fixity name) = return ([DInfixD fixity name], id)
+dsLetDec (PragmaD prag) = do
+  prag' <- dsPragma prag
+  return ([DPragmaD prag'], id)
+#if __GLASGOW_HASKELL__ >= 807
+dsLetDec (ImplicitParamBindD n e) = do
+  new_n_name <- qNewName $ "new_" ++ n ++ "_val"
+  e' <- dsExp e
+  let let_dec :: DLetDec
+      let_dec = DValD (DVarP new_n_name) e'
+
+      ip_binder :: DExp -> DExp
+      ip_binder = (DVarE 'bindIP        `DAppTypeE`
+                     DLitT (StrTyLit n) `DAppE`
+                     DVarE new_n_name   `DAppE`)
+  return ([let_dec], ip_binder)
+#endif
 dsLetDec _dec = impossible "Illegal declaration in let expression."
 
 -- | Desugar a single @Con@.
@@ -956,10 +1093,20 @@ dsPragma (SpecialiseP n ty m_inl phases) = DSpecialiseP n <$> dsType ty
                                                           <*> pure m_inl
                                                           <*> pure phases
 dsPragma (SpecialiseInstP ty)            = DSpecialiseInstP <$> dsType ty
-dsPragma (RuleP str rbs lhs rhs phases)  = DRuleP str <$> mapM dsRuleBndr rbs
+#if __GLASGOW_HASKELL__ >= 807
+dsPragma (RuleP str mtvbs rbs lhs rhs phases)
+                                         = DRuleP str <$> mapM (mapM dsTvb) mtvbs
+                                                      <*> mapM dsRuleBndr rbs
                                                       <*> dsExp lhs
                                                       <*> dsExp rhs
                                                       <*> pure phases
+#else
+dsPragma (RuleP str rbs lhs rhs phases)  = DRuleP str Nothing
+                                                      <$> mapM dsRuleBndr rbs
+                                                      <*> dsExp lhs
+                                                      <*> dsExp rhs
+                                                      <*> pure phases
+#endif
 #if __GLASGOW_HASKELL__ >= 707
 dsPragma (AnnP target exp)               = DAnnP target <$> dsExp exp
 #endif
@@ -975,10 +1122,21 @@ dsRuleBndr :: DsMonad q => RuleBndr -> q DRuleBndr
 dsRuleBndr (RuleVar n)         = return $ DRuleVar n
 dsRuleBndr (TypedRuleVar n ty) = DTypedRuleVar n <$> dsType ty
 
-#if __GLASGOW_HASKELL__ >= 707
+#if __GLASGOW_HASKELL__ >= 807
 -- | Desugar a @TySynEqn@. (Available only with GHC 7.8+)
-dsTySynEqn :: DsMonad q => TySynEqn -> q DTySynEqn
-dsTySynEqn (TySynEqn lhs rhs) = DTySynEqn <$> mapM dsType lhs <*> dsType rhs
+--
+-- This requires a 'Name' as an argument since 'TySynEqn's did not have
+-- this information prior to GHC 8.8.
+dsTySynEqn :: DsMonad q => Name -> TySynEqn -> q DTySynEqn
+dsTySynEqn _ (TySynEqn mtvbs lhs rhs) =
+  DTySynEqn <$> mapM (mapM dsTvb) mtvbs <*> dsType lhs <*> dsType rhs
+#elif __GLASGOW_HASKELL__ >= 707
+-- | Desugar a @TySynEqn@. (Available only with GHC 7.8+)
+dsTySynEqn :: DsMonad q => Name -> TySynEqn -> q DTySynEqn
+dsTySynEqn n (TySynEqn lhss rhs) = do
+  lhss' <- mapM dsType lhss
+  let lhs' = applyDType (DConT n) $ map DTANormal lhss'
+  DTySynEqn Nothing lhs' <$> dsType rhs
 #endif
 
 -- | Desugar clauses to a function definition
@@ -991,8 +1149,8 @@ dsClauses n (Clause pats (NormalB exp) where_decs : rest) = do
   -- this case is necessary to maintain the roundtrip property.
   rest' <- dsClauses n rest
   exp' <- dsExp exp
-  where_decs' <- dsLetDecs where_decs
-  let exp_with_wheres = maybeDLetE where_decs' exp'
+  (where_decs', ip_binder) <- dsLetDecs where_decs
+  let exp_with_wheres = maybeDLetE where_decs' (ip_binder exp')
   (pats', exp'') <- dsPatsOverExp pats exp_with_wheres
   return $ DClause pats' exp'' : rest'
 dsClauses n clauses@(Clause outer_pats _ _ : _) = do
@@ -1047,6 +1205,12 @@ dsType WildCardT = return DWildCardT
 #endif
 #if __GLASGOW_HASKELL__ >= 801
 dsType (UnboxedSumT arity) = return $ DConT (unboxedSumTypeName arity)
+#endif
+#if __GLASGOW_HASKELL__ >= 807
+dsType (AppKindT t k) = DAppKindT <$> dsType t <*> dsType k
+dsType (ImplicitParamT n t) = do
+  t' <- dsType t
+  return $ DConT ''IP `DAppT` DLitT (StrTyLit n) `DAppT` t'
 #endif
 
 -- | Desugar a @TyVarBndr@
@@ -1148,6 +1312,14 @@ dsPred WildCardT = return [DWildCardT]
 dsPred t@(UnboxedSumT {}) =
   impossible $ "Unboxed sum seen as head of constraint: " ++ show t
 #endif
+#if __GLASGOW_HASKELL__ >= 807
+dsPred (AppKindT t k) = do
+  [p] <- dsPred t
+  (:[]) <$> (DAppKindT p <$> dsType k)
+dsPred (ImplicitParamT n t) = do
+  t' <- dsType t
+  return [DConT ''IP `DAppT` DLitT (StrTyLit n) `DAppT` t']
+#endif
 #endif
 
 -- | Like 'reify', but safer and desugared. Uses local declarations where
@@ -1230,13 +1402,47 @@ applyDExp :: DExp -> [DExp] -> DExp
 applyDExp = foldl DAppE
 
 -- | Apply one 'DType' to a list of arguments
-applyDType :: DType -> [DType] -> DType
-applyDType = foldl DAppT
+applyDType :: DType -> [DTypeArg] -> DType
+applyDType = foldl apply
+  where
+    apply :: DType -> DTypeArg -> DType
+    apply f (DTANormal x) = f `DAppT` x
+    apply f (DTyArg x)    = f `DAppKindT` x
+
+-- | An argument to a type, either a normal type ('DTANormal') or a visible
+-- kind application ('DTyArg').
+--
+-- 'DTypeArg' does not appear directly in the @th-desugar@ AST, but it is
+-- useful when decomposing an application of a 'DType' to its arguments.
+data DTypeArg
+  = DTANormal DType
+  | DTyArg DKind
+  deriving (Show, Typeable, Data, Generic)
+
+-- | Desugar a 'TypeArg'.
+dsTypeArg :: DsMonad q => TypeArg -> q DTypeArg
+dsTypeArg (TANormal t) = DTANormal <$> dsType t
+dsTypeArg (TyArg k)    = DTyArg    <$> dsType k
+
+-- | Filter the normal type arguments from a list of 'DTypeArg's.
+filterDTANormals :: [DTypeArg] -> [DType]
+filterDTANormals = mapMaybe getDTANormal
+  where
+    getDTANormal :: DTypeArg -> Maybe DType
+    getDTANormal (DTANormal t) = Just t
+    getDTANormal (DTyArg {})   = Nothing
 
 -- | Convert a 'DTyVarBndr' into a 'DType'
 dTyVarBndrToDType :: DTyVarBndr -> DType
 dTyVarBndrToDType (DPlainTV a)    = DVarT a
 dTyVarBndrToDType (DKindedTV a k) = DVarT a `DSigT` k
+
+-- | Extract the underlying 'DType' or 'DKind' from a 'DTypeArg'. This forgets
+-- information about whether a type is a normal argument or not, so use with
+-- caution.
+unDTypeArg :: DTypeArg -> DType
+unDTypeArg (DTANormal t) = t
+unDTypeArg (DTyArg k)    = k
 
 -- | Convert a 'Strict' to a 'Bang' in GHCs 7.x. This is just
 -- the identity operation in GHC 8.x, which has no 'Strict'.
@@ -1254,11 +1460,12 @@ strictToBang = id
 -- Take a data type name (which does not belong to a data family) and
 -- apply it to its type variable binders to form a DType.
 nonFamilyDataReturnType :: Name -> [DTyVarBndr] -> DType
-nonFamilyDataReturnType con_name = applyDType (DConT con_name) . map dTyVarBndrToDType
+nonFamilyDataReturnType con_name =
+  applyDType (DConT con_name) . map (DTANormal . dTyVarBndrToDType)
 
 -- Take a data family name and apply it to its argument types to form a
 -- data family instance DType.
-dataFamInstReturnType :: Name -> [DType] -> DType
+dataFamInstReturnType :: Name -> [DTypeArg] -> DType
 dataFamInstReturnType fam_name = applyDType (DConT fam_name)
 
 -- Take a data type (which does not belong to a data family) of the form
@@ -1272,20 +1479,20 @@ nonFamilyDataTvbs tvbs mk = do
 -- Take a data family instance of the form @Foo a :: k -> Type -> Type@ and
 -- return @Foo a (b :: k) (c :: Type)@, where @b@ and @c@ are fresh type
 -- variable names.
-dataFamInstTypes :: DsMonad q => [DType] -> Maybe Kind -> q [DType]
-dataFamInstTypes tys mk = do
+dataFamInstTypeArgs :: DsMonad q => [DTypeArg] -> Maybe Kind -> q [DTypeArg]
+dataFamInstTypeArgs tys mk = do
   extra_tvbs <- mkExtraKindBinders mk
-  pure $ tys ++ map dTyVarBndrToDType extra_tvbs
+  pure $ tys ++ map (DTANormal . dTyVarBndrToDType) extra_tvbs
 
--- Unlike vanilla data types and data family declarations, data family
--- instance declarations do not come equipped with a list of bound type
--- variables (at least not yet—see Trac #14268). This means that we have
--- to reverse engineer this information ourselves from the list of type
--- patterns. We accomplish this by taking the free variables of the types
+-- Data family instance declarations did not come equipped with a list of bound
+-- type variables until GHC 8.8 (and even then, it's optional whether the user
+-- provides them or not). This means that there are situations where we must
+-- reverse engineer this information ourselves from the list of type
+-- arguments. We accomplish this by taking the free variables of the types
 -- and performing a reverse topological sort on them to ensure that the
 -- returned list is well scoped.
-dataFamInstTvbs :: [DType] -> [DTyVarBndr]
-dataFamInstTvbs = toposortTyVarsOf
+dataFamInstTvbsCompat :: [DTypeArg] -> [DTyVarBndr]
+dataFamInstTvbsCompat = toposortTyVarsOf . map unDTypeArg
 
 -- | Take a list of 'DType's, find their free variables, and sort them in
 -- reverse topological order to ensure that they are well scoped. In other
@@ -1312,6 +1519,7 @@ toposortTyVarsOf tys =
           go_ty (DForallT tvbs ctxt t) =
             go_tvbs tvbs (foldMap go_ty ctxt `mappend` go_ty t)
           go_ty (DAppT t1 t2) = go_ty t1 `mappend` go_ty t2
+          go_ty (DAppKindT t k) = go_ty t `mappend` go_ty k
           go_ty (DSigT t k) =
             let kSigs = go_ty k
             in case t of
@@ -1381,6 +1589,27 @@ unravel (DAppT (DAppT DArrowT t1) t2) =
   let (tvbs, cxt, tys, res) = unravel t2 in
   (tvbs, cxt, t1 : tys, res)
 unravel t = ([], [], [], t)
+
+-- | Decompose an applied type into its individual components. For example, this:
+--
+-- @
+-- Proxy \@Type Char
+-- @
+--
+-- would be unfolded to this:
+--
+-- @
+-- ('DConT' ''Proxy, ['DTyArg' ('DConT' ''Type), 'DTANormal' ('DConT' ''Char)])
+-- @
+unfoldDType :: DType -> (DType, [DTypeArg])
+unfoldDType = go []
+  where
+    go :: [DTypeArg] -> DType -> (DType, [DTypeArg])
+    go acc (DForallT _ _ ty) = go acc ty
+    go acc (DAppT ty1 ty2)   = go (DTANormal ty2:acc) ty1
+    go acc (DAppKindT ty ki) = go (DTyArg ki:acc) ty
+    go acc (DSigT ty _)      = go acc ty
+    go acc ty                = (ty, acc)
 
 -- | Extract the kind from a 'TyVarBndr', if one is present.
 extractTvbKind :: DTyVarBndr -> Maybe DKind

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -59,6 +59,7 @@ fvDType = go
     go :: DType -> Set Name
     go (DForallT tvbs ctxt ty) = fv_dtvbs tvbs (foldMap fvDType ctxt <> go ty)
     go (DAppT t1 t2)           = go t1 <> go t2
+    go (DAppKindT t k)         = go t <> go k
     go (DSigT ty ki)           = go ty <> go ki
     go (DVarT n)               = S.singleton n
     go (DConT {})              = S.empty
@@ -85,13 +86,13 @@ fv_dpragma :: DPragma -> Set Name
 fv_dpragma = go
   where
     go :: DPragma -> Set Name
-    go (DInlineP {})               = S.empty
-    go (DSpecialiseP _ ty _ _)     = fvDType ty
-    go (DSpecialiseInstP ty)       = fvDType ty
-    go (DRuleP _ rbndrs lhs rhs _) = fv_drule_bndrs rbndrs (fvDExp lhs <> fvDExp rhs)
-    go (DAnnP _ e)                 = fvDExp e
-    go (DLineP {})                 = S.empty
-    go (DCompleteP cns tn)         = S.fromList cns <> foldMap S.singleton tn
+    go (DInlineP {})                 = S.empty
+    go (DSpecialiseP _ ty _ _)       = fvDType ty
+    go (DSpecialiseInstP ty)         = fvDType ty
+    go (DRuleP _ _ rbndrs lhs rhs _) = fv_drule_bndrs rbndrs (fvDExp lhs <> fvDExp rhs)
+    go (DAnnP _ e)                   = fvDExp e
+    go (DLineP {})                   = S.empty
+    go (DCompleteP cns tn)           = S.fromList cns <> foldMap S.singleton tn
 
 -----
 -- Extracting bound term names

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -7,13 +7,7 @@ Compute free variables of programs.
 
 {-# LANGUAGE CPP #-}
 module Language.Haskell.TH.Desugar.FV
-  ( fvDExp
-  , fvDMatch
-  , fvDClause
-  , fvDType
-  , fvDLetDecs
-
-  , extractBoundNamesDLetDec
+  ( fvDType
   , extractBoundNamesDPat
   ) where
 
@@ -27,30 +21,6 @@ import qualified Data.Set as S
 import Data.Set (Set)
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Desugar.AST
-
--- | Compute the free variables of a 'DExp'.
-fvDExp :: DExp -> Set Name
-fvDExp = go
-  where
-    go :: DExp -> Set Name
-    go (DVarE n)         = S.singleton n
-    go (DConE {})        = S.empty
-    go (DLitE {})        = S.empty
-    go (DAppE e1 e2)     = go e1 <> go e2
-    go (DAppTypeE e t)   = go e <> fvDType t
-    go (DLamE ns e)      = go e S.\\ S.fromList ns
-    go (DCaseE scrut ms) = go scrut <> foldMap fvDMatch ms
-    go (DLetE lds e)     = fvDLetDecs lds (go e)
-    go (DSigE e t)       = go e <> fvDType t
-    go (DStaticE e)      = go e
-
--- | Compute the free variables of a 'DMatch'.
-fvDMatch :: DMatch -> Set Name
-fvDMatch (DMatch pa e) = fv_dpat pa (fvDExp e)
-
--- | Compute the free variables of a 'DClause'.
-fvDClause :: DClause -> Set Name
-fvDClause (DClause pas e) = fv_dpats pas (fvDExp e)
 
 -- | Compute the free variables of a 'DType'.
 fvDType :: DType -> Set Name
@@ -67,52 +37,9 @@ fvDType = go
     go (DLitT {})              = S.empty
     go DWildCardT              = S.empty
 
--- | Compute the free variables of a single 'DLetDec'.
---
--- If you are trying to compute the free variables of a list of 'DLetDec's, use
--- 'fv_dletdecs' instead, since it takes recursive @let@-bindings into account.
-fv_dletdec :: DLetDec -> Set Name
-fv_dletdec = go
-  where
-    go :: DLetDec -> Set Name
-    go (DFunD n cs)    = S.delete n (foldMap fvDClause cs)
-    go (DValD pa e)    = fv_dpat pa (fvDExp e)
-    go (DSigD _ t)     = fvDType t -- A function's type can't mention its name
-    go (DInfixD _ n)   = S.singleton n
-    go (DPragmaD prag) = fv_dpragma prag
-
--- | Compute the free variables of a 'DPragma'.
-fv_dpragma :: DPragma -> Set Name
-fv_dpragma = go
-  where
-    go :: DPragma -> Set Name
-    go (DInlineP {})                 = S.empty
-    go (DSpecialiseP _ ty _ _)       = fvDType ty
-    go (DSpecialiseInstP ty)         = fvDType ty
-    go (DRuleP _ _ rbndrs lhs rhs _) = fv_drule_bndrs rbndrs (fvDExp lhs <> fvDExp rhs)
-    go (DAnnP _ e)                   = fvDExp e
-    go (DLineP {})                   = S.empty
-    go (DCompleteP cns tn)           = S.fromList cns <> foldMap S.singleton tn
-
 -----
 -- Extracting bound term names
 -----
-
--- | Extract the term variables bound by a 'DLetDec'.
---
--- This does /not/ extract any type variables bound by pattern signatures
--- within 'DValD's.
--- (GHC won't accept something like @let Just (x :: [a]) = Just \"a\" in id \@a 'x'@
--- anyways.)
-extractBoundNamesDLetDec :: DLetDec -> Set Name
-extractBoundNamesDLetDec = go
-  where
-    go :: DLetDec -> Set Name
-    go (DFunD n _)   = S.singleton n
-    go (DValD pa _)  = extractBoundNamesDPat pa
-    go (DSigD n _)   = S.singleton n
-    go (DInfixD {})  = S.empty
-    go (DPragmaD {}) = S.empty
 
 -- | Extract the term variables bound by a 'DPat'.
 --
@@ -132,39 +59,6 @@ extractBoundNamesDPat = go
 -----
 -- Binding forms
 -----
-
--- | Adjust the free variables of something following 'DLetDec's.
-fvDLetDecs :: [DLetDec] -> Set Name -> Set Name
-fvDLetDecs lds fvs = (foldMap fv_dletdec lds <> fvs)
-                        S.\\ foldMap extractBoundNamesDLetDec lds
-
--- | Adjust the free variables of something following 'DRuleBndr's.
-fv_drule_bndrs :: [DRuleBndr] -> Set Name -> Set Name
-fv_drule_bndrs rbndrs fvs = foldr fv_drule_bndr fvs rbndrs
-
--- | Adjust the free variables of something following a 'DRuleBndr'.
-fv_drule_bndr :: DRuleBndr -> Set Name -> Set Name
-fv_drule_bndr (DRuleVar n)        fvs = S.delete n fvs
-fv_drule_bndr (DTypedRuleVar n t) fvs = S.delete n fvs <> fvDType t
-
--- | Adjust the free variables of something following 'DPat's.
-fv_dpats :: [DPat] -> Set Name -> Set Name
-fv_dpats pas fvs = foldr fv_dpat fvs pas
-
--- | Adjust the free variables of something following a 'DPat'.
-fv_dpat :: DPat -> Set Name -> Set Name
-fv_dpat dpa fvs = go dpa
-  where
-    go :: DPat -> Set Name
-    go (DLitP {})    = fvs
-    go (DVarP n)     = S.delete n fvs
-    go (DConP _ pas) = fv_dpats pas fvs
-    go (DTildeP pa)  = go pa
-    go (DBangP  pa)  = go pa
-    go (DSigP pa t)  = go pa S.\\ fvDType t
-                          -- Unlike extractBoundNamesDPat, this /does/ extract
-                          -- type variables bound by pattern signatures.
-    go DWildP        = fvs
 
 -- | Adjust the free variables of something following 'DTyVarBndr's.
 fv_dtvbs :: [DTyVarBndr] -> Set Name -> Set Name

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -38,4 +38,6 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DTyVarBndr
 #if __GLASGOW_HASKELL__ < 801
                  , ''PatSynArgs
 #endif
+
+                 , ''TypeArg, ''DTypeArg
                  ])

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -373,7 +373,7 @@ maybeReifyCon n decs ty_name ty_args cons
 #if __GLASGOW_HASKELL__ < 711
     fixity = fromMaybe defaultFixity $ reifyFixityInDecs n decs
 #endif
-    tvbs = freeVariablesWellScoped $ map unTypeArg ty_args
+    tvbs = freeVariablesWellScoped $ map probablyWrongUnTypeArg ty_args
 maybeReifyCon _ _ _ _ _ = Nothing
 
 mkVarI :: Name -> [Dec] -> Info

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -265,17 +265,17 @@ reifyInDec n decs (PatSynD n' _ _ _) | n `nameMatches` n'
 
 #if __GLASGOW_HASKELL__ > 710
 reifyInDec n decs (DataD _ ty_name tvbs _mk cons _)
-  | Just info <- maybeReifyCon n decs ty_name (map tvbToTypeWithSig tvbs) cons
+  | Just info <- maybeReifyCon n decs ty_name (map tvbToTANormalWithSig tvbs) cons
   = Just info
 reifyInDec n decs (NewtypeD _ ty_name tvbs _mk con _)
-  | Just info <- maybeReifyCon n decs ty_name (map tvbToTypeWithSig tvbs) [con]
+  | Just info <- maybeReifyCon n decs ty_name (map tvbToTANormalWithSig tvbs) [con]
   = Just info
 #else
 reifyInDec n decs (DataD _ ty_name tvbs cons _)
-  | Just info <- maybeReifyCon n decs ty_name (map tvbToTypeWithSig tvbs) cons
+  | Just info <- maybeReifyCon n decs ty_name (map tvbToTANormalWithSig tvbs) cons
   = Just info
 reifyInDec n decs (NewtypeD _ ty_name tvbs con _)
-  | Just info <- maybeReifyCon n decs ty_name (map tvbToTypeWithSig tvbs) [con]
+  | Just info <- maybeReifyCon n decs ty_name (map tvbToTANormalWithSig tvbs) [con]
   = Just info
 #endif
 #if __GLASGOW_HASKELL__ > 710
@@ -303,25 +303,34 @@ reifyInDec n decs (InstanceD _ _ sub_decs)
     reify_in_instance dec@(DataInstD {})    = reifyInDec n (sub_decs ++ decs) dec
     reify_in_instance dec@(NewtypeInstD {}) = reifyInDec n (sub_decs ++ decs) dec
     reify_in_instance _                     = Nothing
-#if __GLASGOW_HASKELL__ > 710
+#if __GLASGOW_HASKELL__ >= 807
+reifyInDec n decs (DataInstD _ _ lhs _ cons _)
+  | (ConT ty_name, tys) <- unfoldType lhs
+  , Just info <- maybeReifyCon n decs ty_name tys cons
+  = Just info
+reifyInDec n decs (NewtypeInstD _ _ lhs _ con _)
+  | (ConT ty_name, tys) <- unfoldType lhs
+  , Just info <- maybeReifyCon n decs ty_name tys [con]
+  = Just info
+#elif __GLASGOW_HASKELL__ > 710
 reifyInDec n decs (DataInstD _ ty_name tys _ cons _)
-  | Just info <- maybeReifyCon n decs ty_name tys cons
+  | Just info <- maybeReifyCon n decs ty_name (map TANormal tys) cons
   = Just info
 reifyInDec n decs (NewtypeInstD _ ty_name tys _ con _)
-  | Just info <- maybeReifyCon n decs ty_name tys [con]
+  | Just info <- maybeReifyCon n decs ty_name (map TANormal tys) [con]
   = Just info
 #else
 reifyInDec n decs (DataInstD _ ty_name tys cons _)
-  | Just info <- maybeReifyCon n decs ty_name tys cons
+  | Just info <- maybeReifyCon n decs ty_name (map TANormal tys) cons
   = Just info
 reifyInDec n decs (NewtypeInstD _ ty_name tys con _)
-  | Just info <- maybeReifyCon n decs ty_name tys [con]
+  | Just info <- maybeReifyCon n decs ty_name (map TANormal tys) [con]
   = Just info
 #endif
 
 reifyInDec _ _ _ = Nothing
 
-maybeReifyCon :: Name -> [Dec] -> Name -> [Type] -> [Con] -> Maybe (Named Info)
+maybeReifyCon :: Name -> [Dec] -> Name -> [TypeArg] -> [Con] -> Maybe (Named Info)
 #if __GLASGOW_HASKELL__ > 710
 maybeReifyCon n _decs ty_name ty_args cons
   | Just (n', con) <- findCon n cons
@@ -341,8 +350,8 @@ maybeReifyCon n decs ty_name ty_args cons
   = Just (n', VarI n (maybeForallT tvbs [] $ mkArrows [result_ty] ty) Nothing fixity)
 #endif
   where
-    result_ty = foldl AppT (ConT ty_name) (map unSigType ty_args)
-      -- Make sure to call unSigType here. Otherwise, if you have this:
+    result_ty = applyType (ConT ty_name) (map unSigTypeArg ty_args)
+      -- Make sure to call unSigTypeArg here. Otherwise, if you have this:
       --
       --   data D (a :: k) = MkD { unD :: Proxy a }
       --
@@ -364,7 +373,7 @@ maybeReifyCon n decs ty_name ty_args cons
 #if __GLASGOW_HASKELL__ < 711
     fixity = fromMaybe defaultFixity $ reifyFixityInDecs n decs
 #endif
-    tvbs = freeVariablesWellScoped ty_args
+    tvbs = freeVariablesWellScoped $ map unTypeArg ty_args
 maybeReifyCon _ _ _ _ _ = Nothing
 
 mkVarI :: Name -> [Dec] -> Info
@@ -409,14 +418,34 @@ findInstances n = map stripInstanceDec . concatMap match_instance
 #endif
                                                | ConT n' <- ty_head ty
                                                , n `nameMatches` n' = [d]
-#if __GLASGOW_HASKELL__ > 710
+#if __GLASGOW_HASKELL__ >= 807
+    match_instance (DataInstD ctxt _ lhs mk cons derivs)
+                                                  | ConT n' <- ty_head lhs
+                                                  , n `nameMatches` n' = [d]
+      where
+        mtvbs = rejig_data_inst_tvbs ctxt lhs mk
+        d = DataInstD ctxt mtvbs lhs mk cons derivs
+    match_instance (NewtypeInstD ctxt _ lhs mk con derivs)
+                                                  | ConT n' <- ty_head lhs
+                                                  , n `nameMatches` n' = [d]
+      where
+        mtvbs = rejig_data_inst_tvbs ctxt lhs mk
+        d = NewtypeInstD ctxt mtvbs lhs mk con derivs
+#elif __GLASGOW_HASKELL__ > 710
     match_instance d@(DataInstD _ n' _ _ _ _)    | n `nameMatches` n' = [d]
     match_instance d@(NewtypeInstD _ n' _ _ _ _) | n `nameMatches` n' = [d]
 #else
     match_instance d@(DataInstD _ n' _ _ _)    | n `nameMatches` n' = [d]
     match_instance d@(NewtypeInstD _ n' _ _ _) | n `nameMatches` n' = [d]
 #endif
-#if __GLASGOW_HASKELL__ >= 707
+#if __GLASGOW_HASKELL__ >= 807
+    match_instance (TySynInstD (TySynEqn _ lhs rhs))
+                                               | ConT n' <- ty_head lhs
+                                               , n `nameMatches` n' = [d]
+      where
+        mtvbs = rejig_tvbs [lhs, rhs]
+        d = TySynInstD (TySynEqn mtvbs lhs rhs)
+#elif __GLASGOW_HASKELL__ >= 707
     match_instance d@(TySynInstD n' _)         | n `nameMatches` n' = [d]
 #else
     match_instance d@(TySynInstD n' _ _)       | n `nameMatches` n' = [d]
@@ -430,10 +459,52 @@ findInstances n = map stripInstanceDec . concatMap match_instance
                                         = concatMap match_instance decs
     match_instance _                    = []
 
-    ty_head (ForallT _ _ ty) = ty_head ty
-    ty_head (AppT ty _)      = ty_head ty
-    ty_head (SigT ty _)      = ty_head ty
-    ty_head ty               = ty
+#if __GLASGOW_HASKELL__ >= 807
+    -- See Note [Rejigging reified type family equations variable binders]
+    -- for why this is necessary.
+    rejig_tvbs :: [Type] -> Maybe [TyVarBndr]
+    rejig_tvbs ts =
+      let tvbs = freeVariablesWellScoped ts
+      in if null tvbs
+         then Nothing
+         else Just tvbs
+
+    rejig_data_inst_tvbs :: Cxt -> Type -> Maybe Kind -> Maybe [TyVarBndr]
+    rejig_data_inst_tvbs cxt lhs mk =
+      rejig_tvbs $ cxt ++ [lhs] ++ maybeToList mk
+#endif
+
+    ty_head = fst . unfoldType
+
+{-
+Note [Rejigging reified type family equations variable binders]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When reifying a type family instance (on GHC 8.8 or later), which quantified
+type variables do you use? This might seem like a strange question to ask since
+these instances already come equipped with a field of type `Maybe [TyVarBndr]`,
+but it's not always the case that you want to use exactly that field. Here is
+an example to better explain it:
+
+  class C a where
+    type T b a
+  instance C (Maybe a) where
+    type forall b. T b (Maybe a) = a
+
+If the above instance were quoted, it would give you `Just [PlainTV b]`. But if
+you were to reify ''T (and therefore retrieve the instance for T), you wouldn't
+want to use that as your list of type variable binders! This is because
+reifiying any type family always presents the information as though the type
+family were top-level. Therefore, reifying T (in GHC, at least) would yield:
+
+  type family T b a
+  type instance forall b a. T b (Maybe a) = a
+
+Note that we quantify over `b` *and* `a` here, not just `b`. To emulate this
+GHC quirk, whenever we reify any type family instance, we just ignore the field
+of type `Maybe [TyVarBndr]` and quantify over the instance afresh. It's a bit
+tedious, but it gets the job done. (This is accomplished by the rejig_tvbs
+function.)
+-}
 
 stripClassDec :: Dec -> Dec
 stripClassDec (ClassD cxt name tvbs fds sub_decs)

--- a/Language/Haskell/TH/Desugar/Subst.hs
+++ b/Language/Haskell/TH/Desugar/Subst.hs
@@ -49,6 +49,8 @@ substTy vars (DForallT tvbs cxt ty) =
     return $ DForallT tvbs' cxt' ty'
 substTy vars (DAppT t1 t2) =
   DAppT <$> substTy vars t1 <*> substTy vars t2
+substTy vars (DAppKindT t k) =
+  DAppKindT <$> substTy vars t <*> substTy vars k
 substTy vars (DSigT ty ki) =
   DSigT <$> substTy vars ty <*> substTy vars ki
 substTy vars (DVarT n)

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -30,7 +30,7 @@ module Language.Haskell.TH.Desugar.Util (
   topEverywhereM, isInfixDataCon,
   isTypeKindName, typeKindName,
   mkExtraKindBindersGeneric, unravelType, unSigType, unfoldType,
-  TypeArg(..), applyType, filterTANormals, unSigTypeArg, unTypeArg
+  TypeArg(..), applyType, filterTANormals, unSigTypeArg, probablyWrongUnTypeArg
 #if __GLASGOW_HASKELL__ >= 800
   , bindIP
 #endif
@@ -319,9 +319,9 @@ unSigTypeArg (TyArg k)    = TyArg (unSigType k)
 -- | Extract the underlying 'Type' or 'Kind' from a 'TypeArg'. This forgets
 -- information about whether a type is a normal argument or not, so use with
 -- caution.
-unTypeArg :: TypeArg -> Type
-unTypeArg (TANormal t) = t
-unTypeArg (TyArg k)    = k
+probablyWrongUnTypeArg :: TypeArg -> Type
+probablyWrongUnTypeArg (TANormal t) = t
+probablyWrongUnTypeArg (TyArg k)    = k
 
 ----------------------------------------
 -- Free names, etc.

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -6,10 +6,12 @@ rae@cs.brynmawr.edu
 Utility functions for th-desugar package.
 -}
 
-{-# LANGUAGE CPP, TupleSections #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, RankNTypes, ScopedTypeVariables, TupleSections #-}
 
 #if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE TypeApplications #-}
 #endif
 
 module Language.Haskell.TH.Desugar.Util (
@@ -21,13 +23,17 @@ module Language.Haskell.TH.Desugar.Util (
   stripPlainTV_maybe,
   thirdOf3, splitAtList, extractBoundNamesDec,
   extractBoundNamesPat,
-  tvbToType, tvbToTypeWithSig, nameMatches, thdOf3, firstMatch,
+  tvbToType, tvbToTANormalWithSig, nameMatches, thdOf3, firstMatch,
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   tupleDegree_maybe, tupleNameDegree_maybe, unboxedTupleDegree_maybe,
   unboxedTupleNameDegree_maybe, splitTuple_maybe,
   topEverywhereM, isInfixDataCon,
   isTypeKindName, typeKindName,
-  mkExtraKindBindersGeneric, unravelType, unSigType
+  mkExtraKindBindersGeneric, unravelType, unSigType, unfoldType,
+  TypeArg(..), applyType, filterTANormals, unSigTypeArg, unTypeArg
+#if __GLASGOW_HASKELL__ >= 800
+  , bindIP
+#endif
   ) where
 
 import Prelude hiding (mapM, foldl, concatMap, any)
@@ -49,6 +55,8 @@ import Data.Monoid
 
 #if __GLASGOW_HASKELL__ >= 800
 import qualified Data.Kind as Kind
+import GHC.Classes ( IP )
+import Unsafe.Coerce ( unsafeCoerce )
 #endif
 
 ----------------------------------------
@@ -118,6 +126,11 @@ tvbToType = VarT . tvName
 tvbToTypeWithSig :: TyVarBndr -> Type
 tvbToTypeWithSig (PlainTV n)    = VarT n
 tvbToTypeWithSig (KindedTV n k) = SigT (VarT n) k
+
+-- | Convert a 'TyVarBndr' into a 'TypeArg' (specifically, a 'TANormal'),
+-- preserving the kind signature (if it has one).
+tvbToTANormalWithSig :: TyVarBndr -> TypeArg
+tvbToTANormalWithSig = TANormal . tvbToTypeWithSig
 
 -- | Do two names name the same thing?
 nameMatches :: Name -> Name -> Bool
@@ -224,6 +237,10 @@ unSigType (InfixT t1 n t2)  = InfixT (unSigType t1) n (unSigType t2)
 unSigType (UInfixT t1 n t2) = UInfixT (unSigType t1) n (unSigType t2)
 unSigType (ParensT t)       = ParensT (unSigType t)
 #endif
+#if __GLASGOW_HASKELL__ >= 807
+unSigType (AppKindT t k)       = AppKindT (unSigType t) (unSigType k)
+unSigType (ImplicitParamT n t) = ImplicitParamT n (unSigType t)
+#endif
 unSigType t = t
 
 -- | Remove all of the explicit kind signatures from a 'Pred'.
@@ -234,6 +251,77 @@ unSigPred = unSigType
 unSigPred (ClassP n tys) = ClassP n (map unSigType tys)
 unSigPred (EqualP t1 t2) = EqualP (unSigType t1) (unSigType t2)
 #endif
+
+-- | Decompose an applied type into its individual components. For example, this:
+--
+-- @
+-- Proxy \@Type Char
+-- @
+--
+-- would be unfolded to this:
+--
+-- @
+-- ('ConT' ''Proxy, ['TyArg' ('ConT' ''Type), 'TANormal' ('ConT' ''Char)])
+-- @
+unfoldType :: Type -> (Type, [TypeArg])
+unfoldType = go []
+  where
+    go :: [TypeArg] -> Type -> (Type, [TypeArg])
+    go acc (ForallT _ _ ty) = go acc ty
+    go acc (AppT ty1 ty2)   = go (TANormal ty2:acc) ty1
+    go acc (SigT ty _)      = go acc ty
+#if __GLASGOW_HASKELL__ >= 800
+    go acc (ParensT ty)     = go acc ty
+#endif
+#if __GLASGOW_HASKELL__ >= 807
+    go acc (AppKindT ty ki) = go (TyArg ki:acc) ty
+#endif
+    go acc ty               = (ty, acc)
+
+-- | An argument to a type, either a normal type ('TANormal') or a visible
+-- kind application ('TyArg').
+--
+-- 'TypeArg' is useful when decomposing an application of a 'Type' to its
+-- arguments (e.g., in 'unfoldType').
+data TypeArg
+  = TANormal Type
+  | TyArg Kind
+  deriving (Show, Typeable, Data)
+
+-- | Apply one 'Type' to a list of arguments.
+applyType :: Type -> [TypeArg] -> Type
+applyType = foldl apply
+  where
+    apply :: Type -> TypeArg -> Type
+    apply f (TANormal x) = f `AppT` x
+    apply f (TyArg _x)   =
+#if __GLASGOW_HASKELL__ >= 807
+                           f `AppKindT` _x
+#else
+                           -- VKA isn't supported, so
+                           -- conservatively drop the argument
+                           f
+#endif
+
+-- | Filter the normal type arguments from a list of 'TypeArg's.
+filterTANormals :: [TypeArg] -> [Type]
+filterTANormals = mapMaybe getTANormal
+  where
+    getTANormal :: TypeArg -> Maybe Type
+    getTANormal (TANormal t) = Just t
+    getTANormal (TyArg {})   = Nothing
+
+-- | Remove all of the explicit kind signatures from a 'TypeArg'.
+unSigTypeArg :: TypeArg -> TypeArg
+unSigTypeArg (TANormal t) = TANormal (unSigType t)
+unSigTypeArg (TyArg k)    = TyArg (unSigType k)
+
+-- | Extract the underlying 'Type' or 'Kind' from a 'TypeArg'. This forgets
+-- information about whether a type is a normal argument or not, so use with
+-- caution.
+unTypeArg :: TypeArg -> Type
+unTypeArg (TANormal t) = t
+unTypeArg (TyArg k)    = k
 
 ----------------------------------------
 -- Free names, etc.
@@ -253,6 +341,9 @@ extractBoundNamesStmt (BindS pat _) = extractBoundNamesPat pat
 extractBoundNamesStmt (LetS decs)   = foldMap extractBoundNamesDec decs
 extractBoundNamesStmt (NoBindS _)   = S.empty
 extractBoundNamesStmt (ParS stmtss) = foldMap (foldMap extractBoundNamesStmt) stmtss
+#if __GLASGOW_HASKELL__ >= 807
+extractBoundNamesStmt (RecS stmtss) = foldMap extractBoundNamesStmt stmtss
+#endif
 
 -- | Extract the names bound in a @Dec@ that could appear in a @let@ expression.
 extractBoundNamesDec :: Dec -> S.Set Name
@@ -288,6 +379,18 @@ extractBoundNamesPat (UnboxedSumP pat _ _) = extractBoundNamesPat pat
 ----------------------------------------
 -- General utility
 ----------------------------------------
+
+#if __GLASGOW_HASKELL__ >= 800
+-- dirty implementation of explicit-to-implicit conversion
+newtype MagicIP name a r = MagicIP (IP name a => r)
+
+-- | Get an implicit param constraint (@IP name a@, which is the desugared
+-- form of @(?name :: a)@) from an explicit value.
+--
+-- This function is only available with GHC 8.0 or later.
+bindIP :: forall name a r. a -> (IP name a => r) -> r
+bindIP val k = (unsafeCoerce (MagicIP @name k) :: a -> r) val
+#endif
 
 -- like GHC's
 splitAtList :: [a] -> [b] -> ([b], [b])

--- a/README.md
+++ b/README.md
@@ -85,3 +85,6 @@ The following constructs are known to be susceptible to this issue:
 1. Desugared Haskell98-style constructors
 2. Locally reified class methods
 3. Locally reified record selectors
+4. Locally reified data constructors
+5. Locally reified type family instances (on GHC 8.8 and later, in which the
+   Template Haskell AST supports explicit `foralls` in type family equations)

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -48,7 +48,6 @@ import qualified Language.Haskell.TH.Syntax as Syn ( lift )
 import Control.Monad
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
-import Data.Foldable (foldMap)
 #endif
 
 import Data.Generics ( geq )
@@ -363,11 +362,6 @@ test_t103 =
 test_fvs :: [Bool]
 test_fvs =
   $(do a <- newName "a"
-       f <- newName "f"
-       g <- newName "g"
-       x <- newName "x"
-       y <- newName "y"
-       z <- newName "z"
 
        let -- (Show a => Show (Maybe a)) => String
            ty1 = DForallT
@@ -377,31 +371,7 @@ test_fvs =
                    (DConT ''String)
            b1 = fvDType ty1 `eqTH` S.singleton a -- #93
 
-           -- let f x = g x
-           --     g x = f x
-           -- in ()
-           lds2 = [ DFunD f [DClause [DVarP x] (DVarE g `DAppE` DVarE x)]
-                  , DFunD g [DClause [DVarP x] (DVarE f `DAppE` DVarE x)]
-                  ]
-           b2a = fvDLetDecs lds2 S.empty `eqTH` S.empty
-           b2b = foldMap extractBoundNamesDLetDec lds2 `eqTH` S.fromList [f, g]
-
-           -- case x of
-           --   Just y -> \z -> f x y z
-           e3 = DCaseE (DVarE x)
-                       [DMatch (DConP 'Just [DVarP y])
-                               (DLamE [z] (DVarE f `DAppE` DVarE x
-                                                   `DAppE` DVarE y
-                                                   `DAppE` DVarE z))]
-           b3 = fvDExp e3 `eqTH` S.fromList [f, x]
-
-           -- some_function (Just (x :: [a])) = f @a
-           p4  = DConP 'Just [DSigP (DVarP x) (DConT ''[] `DAppT` DVarT a)]
-           c4  = DClause [p4] (DVarE f `DAppTypeE` DVarT a)
-           b4a = fvDClause c4 `eqTH` S.singleton f
-           b4b = extractBoundNamesDPat p4 `eqTH` S.fromList [x]
-
-       [| [b1, b2a, b2b, b3, b4a, b4b] |])
+       [| [b1] |])
 
 test_kind_substitution :: [Bool]
 test_kind_substitution =

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -43,7 +43,8 @@ source-repository head
 library
   build-depends:
       base >= 4 && < 5,
-      template-haskell >= 2.8 && < 2.15,
+      ghc-prim,
+      template-haskell >= 2.8 && < 2.16,
       containers >= 0.5,
       mtl >= 2.1,
       syb >= 0.4,


### PR DESCRIPTION
This adds support for:

* Visible kind application
* More explicit foralls
* Implicit params

Although `template-haskell-2.15` also adds support for `RecursiveDo`, desugaring it proves to be rather involved, so I've decided to punt on this.

Fixes #90.