### PR TITLE
Make th-desugar deterministic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,8 @@ Version 1.10
   of type variable binders in `forall`s.
 * Fix a bug in which `getRecordSelectors` would omit record selectors from
   GADT constructors.
+* Fix a bug in which `toposortTyVarsOf` would sometimes not preserve
+  the left-to-right ordering of `Name`s generated with `qNewName`.
 * Locally reified class methods, data constructors, and record selectors now
   quantify kind variables properly.
 * Desugared ADT constructors now quantify kind variables properly.

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -17,25 +17,25 @@ import Data.Foldable (foldMap)
 #if __GLASGOW_HASKELL__ < 804
 import Data.Monoid ((<>))
 #endif
-import qualified Data.Set as S
-import Data.Set (Set)
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Desugar.AST
+import qualified Language.Haskell.TH.Desugar.OSet as OS
+import Language.Haskell.TH.Desugar.OSet (OSet)
 
 -- | Compute the free variables of a 'DType'.
-fvDType :: DType -> Set Name
+fvDType :: DType -> OSet Name
 fvDType = go
   where
-    go :: DType -> Set Name
+    go :: DType -> OSet Name
     go (DForallT tvbs ctxt ty) = fv_dtvbs tvbs (foldMap fvDType ctxt <> go ty)
     go (DAppT t1 t2)           = go t1 <> go t2
     go (DAppKindT t k)         = go t <> go k
     go (DSigT ty ki)           = go ty <> go ki
-    go (DVarT n)               = S.singleton n
-    go (DConT {})              = S.empty
-    go DArrowT                 = S.empty
-    go (DLitT {})              = S.empty
-    go DWildCardT              = S.empty
+    go (DVarT n)               = OS.singleton n
+    go (DConT {})              = OS.empty
+    go DArrowT                 = OS.empty
+    go (DLitT {})              = OS.empty
+    go DWildCardT              = OS.empty
 
 -----
 -- Extracting bound term names
@@ -44,27 +44,27 @@ fvDType = go
 -- | Extract the term variables bound by a 'DPat'.
 --
 -- This does /not/ extract any type variables bound by pattern signatures.
-extractBoundNamesDPat :: DPat -> Set Name
+extractBoundNamesDPat :: DPat -> OSet Name
 extractBoundNamesDPat = go
   where
-    go :: DPat -> Set Name
-    go (DLitP _)      = S.empty
-    go (DVarP n)      = S.singleton n
+    go :: DPat -> OSet Name
+    go (DLitP _)      = OS.empty
+    go (DVarP n)      = OS.singleton n
     go (DConP _ pats) = foldMap go pats
     go (DTildeP p)    = go p
     go (DBangP p)     = go p
     go (DSigP p _)    = go p
-    go DWildP         = S.empty
+    go DWildP         = OS.empty
 
 -----
 -- Binding forms
 -----
 
 -- | Adjust the free variables of something following 'DTyVarBndr's.
-fv_dtvbs :: [DTyVarBndr] -> Set Name -> Set Name
+fv_dtvbs :: [DTyVarBndr] -> OSet Name -> OSet Name
 fv_dtvbs tvbs fvs = foldr fv_dtvb fvs tvbs
 
 -- | Adjust the free variables of something following a 'DTyVarBndr'.
-fv_dtvb :: DTyVarBndr -> Set Name -> Set Name
-fv_dtvb (DPlainTV n)    fvs = S.delete n fvs
-fv_dtvb (DKindedTV n k) fvs = S.delete n fvs <> fvDType k
+fv_dtvb :: DTyVarBndr -> OSet Name -> OSet Name
+fv_dtvb (DPlainTV n)    fvs = OS.delete n fvs
+fv_dtvb (DKindedTV n k) fvs = OS.delete n fvs <> fvDType k

--- a/Language/Haskell/TH/Desugar/OMap.hs
+++ b/Language/Haskell/TH/Desugar/OMap.hs
@@ -1,0 +1,51 @@
+{- Language/Haskell/TH/Desugar/OMap.hs
+
+(c) Daniel Wagner 2016-2018, Ryan Scott 2019
+-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Language.Haskell.TH.Desugar.OMap
+-- Copyright   :  (C) 2016-2018 Daniel Wagner, 2019 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Ryan Scott
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- An 'OMap' behaves much like a 'M.Map', with all the same asymptotics, but
+-- also remembers the order that keys were inserted.
+--
+----------------------------------------------------------------------------
+module Language.Haskell.TH.Desugar.OMap
+    ( OMap
+    -- * Trivial maps
+    , empty, singleton
+    -- * Insertion
+    -- | Conventions:
+    --
+    -- * The open side of an angle bracket points to an 'OMap'
+    --
+    -- * The pipe appears on the side whose indices take precedence if both sides contain the same key
+    --
+    -- * The left argument's indices are lower than the right argument's indices
+    --
+    -- * If both sides contain the same key, the tuple's value wins
+    , (<|), (|<), (>|), (|>)
+    , (<>|), (|<>)
+    -- * Deletion
+    , delete, filter, (\\)
+    -- * Query
+    , null, size, member, notMember, lookup
+    -- * Indexing
+    , Index, findIndex, elemAt
+    -- * List conversions
+    , fromList, assocs, toAscList
+    ) where
+
+import qualified Data.Map.Lazy as M
+import Language.Haskell.TH.Desugar.OMap.Internal
+import Language.Haskell.TH.Desugar.OMapSetUtil
+import Prelude hiding (filter, foldr, lookup, null)
+
+singleton :: k -> v -> OMap k v
+singleton k v = OMap (M.singleton k (0, v)) (M.singleton 0 (k, v))

--- a/Language/Haskell/TH/Desugar/OMap/Internal.hs
+++ b/Language/Haskell/TH/Desugar/OMap/Internal.hs
@@ -1,0 +1,171 @@
+{- Language/Haskell/TH/Desugar/OMap/Internal.hs
+
+(c) Daniel Wagner 2016-2018, Ryan Scott 2019
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+module Language.Haskell.TH.Desugar.OMap.Internal where
+
+import Control.Monad (guard)
+import Data.Data
+import Data.Foldable (foldl')
+import Data.Function (on)
+import Data.Map (Map)
+import Language.Haskell.TH.Desugar.OMapSetUtil (Index, Tag, maxTag, minTag, nextHigherTag, nextLowerTag, readsPrecList, showsPrecList)
+import Prelude hiding (filter, lookup, null)
+import qualified Data.Map as M
+
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Foldable (Foldable, foldMap)
+import Data.Monoid (Monoid(..))
+#endif
+
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
+#endif
+
+data OMap k v = OMap !(Map k (Tag, v)) !(Map Tag (k, v))
+
+instance Functor (OMap k) where
+  fmap f (OMap tvs kvs) = OMap (fmap (\(t, v) -> (t, f v)) tvs)
+                               (fmap (\(k, v) -> (k, f v)) kvs)
+-- | Values are produced in insertion order, not key order.
+instance Foldable (OMap k) where foldMap f (OMap _ kvs) = foldMap (f . snd) kvs
+instance (       Eq   k, Eq   v) => Eq   (OMap k v) where (==)    = (==)    `on` assocs
+instance (       Ord  k, Ord  v) => Ord  (OMap k v) where compare = compare `on` assocs
+instance (       Show k, Show v) => Show (OMap k v) where showsPrec = showsPrecList assocs
+instance (Ord k, Read k, Read v) => Read (OMap k v) where readsPrec = readsPrecList fromList
+instance Ord k => Semigroup (OMap k v) where
+  (<>) = (|<>)
+instance Ord k => Monoid (OMap k v) where
+  mempty = empty
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
+
+# if __GLASGOW_HASKELL__ >= 708
+deriving instance Typeable OMap
+# else
+deriving instance Typeable2 OMap
+# endif
+
+-- This instance preserves data abstraction at the cost of inefficiency.
+-- We provide limited reflection services for the sake of data abstraction.
+
+instance (Data k, Data a, Ord k) => Data (OMap k a) where
+  gfoldl f z m   = z fromList `f` assocs m
+  toConstr _     = fromListConstr
+  gunfold k z c  = case constrIndex c of
+    1 -> k (z fromList)
+    _ -> error "gunfold"
+  dataTypeOf _   = oMapDataType
+  dataCast2 f    = gcast2 f
+
+fromListConstr :: Constr
+fromListConstr = mkConstr oMapDataType "fromList" [] Prefix
+
+oMapDataType :: DataType
+oMapDataType = mkDataType "Data.Map.Ordered.Map" [fromListConstr]
+
+infixr 5 <|, |< -- copy :
+infixl 5 >|, |>
+infixr 6 <>|, |<> -- copy <>
+
+(<|) , (|<)  :: Ord k => (,)  k v -> OMap k v -> OMap k v
+(>|) , (|>)  :: Ord k => OMap k v -> (,)  k v -> OMap k v
+(<>|), (|<>) :: Ord k => OMap k v -> OMap k v -> OMap k v
+
+(k, v) <| OMap tvs kvs = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = maybe (nextLowerTag kvs) fst (M.lookup k tvs)
+
+(k, v) |< o = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = nextLowerTag kvs
+    OMap tvs kvs = delete k o
+
+o >| (k, v) = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = nextHigherTag kvs
+    OMap tvs kvs = delete k o
+
+OMap tvs kvs |> (k, v) = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = maybe (nextHigherTag kvs) fst (M.lookup k tvs)
+
+o <>| o' = unsafeMappend (o \\ o') o'
+o |<> o' = unsafeMappend o (o' \\ o)
+
+-- assumes that ts and ts' have disjoint keys
+unsafeMappend :: Ord k => OMap k v -> OMap k v -> OMap k v
+unsafeMappend (OMap ts vs) (OMap ts' vs')
+    = OMap (M.union tsBumped tsBumped')
+           (M.union vsBumped vsBumped')
+    where
+    bump  = case maxTag vs  of
+        Nothing -> 0
+        Just k  -> -k-1
+    bump' = case minTag vs' of
+        Nothing -> 0
+        Just k  -> -k
+    tsBumped  = fmap (\(t, v) -> (bump + t, v)) ts
+    tsBumped' = fmap (\(t, v) -> (bump'+ t, v)) ts'
+    vsBumped  = (bump +) `M.mapKeysMonotonic` vs
+    vsBumped' = (bump'+) `M.mapKeysMonotonic` vs'
+
+-- | @m \\\\ n@ deletes all the keys that exist in @n@ from @m@
+(\\) :: Ord k => OMap k v -> OMap k v' -> OMap k v
+o@(OMap _ _) \\ o'@(OMap _ _) = if size o < size o'
+    then filter (const . (`notMember` o')) o
+    else foldr delete o (fmap fst (assocs o'))
+
+empty :: OMap k v
+empty = OMap M.empty M.empty
+
+-- | If a key appears multiple times, the first occurrence is used for ordering
+-- and the last occurrence is used for its value. The library author welcomes
+-- comments on whether this default is sane.
+fromList :: Ord k => [(k, v)] -> OMap k v
+fromList = foldl' (|>) empty
+
+null :: OMap k v -> Bool
+null (OMap tvs _) = M.null tvs
+
+size :: OMap k v -> Int
+size (OMap tvs _) = M.size tvs
+
+member, notMember :: Ord k => k -> OMap k v -> Bool
+member    k (OMap tvs _) = M.member    k tvs
+notMember k (OMap tvs _) = M.notMember k tvs
+
+lookup :: Ord k => k -> OMap k v -> Maybe v
+lookup k (OMap tvs _) = fmap snd (M.lookup k tvs)
+
+-- The Ord constraint is for compatibility with older (<0.5) versions of
+-- containers.
+-- | @filter f m@ contains exactly the key-value pairs of @m@ that satisfy @f@,
+-- without changing the order they appear
+filter :: Ord k => (k -> v -> Bool) -> OMap k v -> OMap k v
+filter f (OMap tvs kvs) = OMap (M.filterWithKey (\k (_, v) -> f k v) tvs)
+                               (M.filterWithKey (\_ (k, v) -> f k v) kvs)
+
+delete :: Ord k => k -> OMap k v -> OMap k v
+delete k o@(OMap tvs kvs) = case M.lookup k tvs of
+    Nothing     -> o
+    Just (t, _) -> OMap (M.delete k tvs) (M.delete t kvs)
+
+findIndex :: Ord k => k -> OMap k v -> Maybe Index
+findIndex k (OMap tvs kvs) = do
+    (t, _) <- M.lookup k tvs
+    M.lookupIndex t kvs
+
+elemAt :: OMap k v -> Index -> Maybe (k, v)
+elemAt (OMap _ kvs) i = do
+    guard (0 <= i && i < M.size kvs)
+    return . snd $ M.elemAt i kvs
+
+-- | Return key-value pairs in the order they were inserted.
+assocs :: OMap k v -> [(k, v)]
+assocs (OMap _ kvs) = map snd $ M.toAscList kvs
+
+-- | Return key-value pairs in order of increasing key.
+toAscList :: OMap k v -> [(k, v)]
+toAscList (OMap tvs _) = map (\(k, (_, v)) -> (k, v)) $ M.toAscList tvs

--- a/Language/Haskell/TH/Desugar/OMap/Strict.hs
+++ b/Language/Haskell/TH/Desugar/OMap/Strict.hs
@@ -1,0 +1,78 @@
+{- Language/Haskell/TH/Desugar/OMap/Strict.hs
+
+(c) Daniel Wagner 2016-2018, Ryan Scott 2019
+-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Language.Haskell.TH.Desugar.OMap
+-- Copyright   :  (C) 2016-2018 Daniel Wagner, 2019 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Ryan Scott
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- An 'OMap' behaves much like a 'M.Map', with all the same asymptotics, but
+-- also remembers the order that keys were inserted.
+--
+----------------------------------------------------------------------------
+module Language.Haskell.TH.Desugar.OMap.Strict
+    ( OMap
+    -- * Trivial maps
+    , empty, singleton
+    -- * Insertion
+    -- | Conventions:
+    --
+    -- * The open side of an angle bracket points to an 'OMap'
+    --
+    -- * The pipe appears on the side whose indices take precedence if both sides contain the same key
+    --
+    -- * The left argument's indices are lower than the right argument's indices
+    --
+    -- * If both sides contain the same key, the tuple's value wins
+    , (<|), (|<), (>|), (|>)
+    , (<>|), (|<>)
+    -- * Deletion
+    , delete, filter, (\\)
+    -- * Query
+    , null, size, member, notMember, lookup
+    -- * Indexing
+    , Index, findIndex, elemAt
+    -- * List conversions
+    , fromList, assocs, toAscList
+    ) where
+
+import Data.Foldable (foldl')
+import qualified Data.Map.Strict as M
+import Language.Haskell.TH.Desugar.OMap.Internal hiding ((<|), (|<), (>|), (|>), fromList)
+import Language.Haskell.TH.Desugar.OMapSetUtil
+import Prelude hiding (filter, foldr, lookup, null)
+
+infixr 5 <|, |< -- copy :
+infixl 5 >|, |>
+
+(<|) , (|<)  :: Ord k => (,)  k v -> OMap k v -> OMap k v
+(>|) , (|>)  :: Ord k => OMap k v -> (,)  k v -> OMap k v
+
+(k, v) <| OMap tvs kvs = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = maybe (nextLowerTag kvs) fst (M.lookup k tvs)
+
+(k, v) |< o = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = nextLowerTag kvs
+    OMap tvs kvs = delete k o
+
+o >| (k, v) = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = nextHigherTag kvs
+    OMap tvs kvs = delete k o
+
+OMap tvs kvs |> (k, v) = OMap (M.insert k (t, v) tvs) (M.insert t (k, v) kvs) where
+    t = maybe (nextHigherTag kvs) fst (M.lookup k tvs)
+
+singleton :: k -> v -> OMap k v
+singleton k v = OMap (M.singleton k (0, v)) (M.singleton 0 (k, v))
+
+-- | If a key appears multiple times, the first occurrence is used for ordering
+-- and the last occurrence is used for its value. The library author welcomes
+-- comments on whether this default is sane.
+fromList :: Ord k => [(k, v)] -> OMap k v
+fromList = foldl' (|>) empty

--- a/Language/Haskell/TH/Desugar/OMapSetUtil.hs
+++ b/Language/Haskell/TH/Desugar/OMapSetUtil.hs
@@ -1,0 +1,35 @@
+{- Language/Haskell/TH/Desugar/OMapSetUtil.hs
+
+(c) Daniel Wagner 2016-2018, Ryan Scott 2019
+-}
+module Language.Haskell.TH.Desugar.OMapSetUtil where
+
+import Data.Map (Map)
+import qualified Data.Map as M
+
+-- | An internal index used to track ordering only -- its magnitude doesn't
+-- matter. If you manage to see this documentation, the library author has made
+-- a mistake!
+type Tag = Int
+
+-- | A 0-based index, much like the indices used by lists' '!!' operation. All
+-- indices are with respect to insertion order.
+type Index = Int
+
+nextLowerTag, nextHigherTag :: Map Tag a -> Tag
+nextLowerTag  = maybe 0 pred . minTag
+nextHigherTag = maybe 0 succ . maxTag
+
+minTag, maxTag :: Map Tag a -> Maybe Tag
+minTag m = fmap (fst . fst) (M.minViewWithKey m)
+maxTag m = fmap (fst . fst) (M.maxViewWithKey m)
+
+showsPrecList :: Show a => (b -> [a]) -> Int -> b -> ShowS
+showsPrecList toList d o = showParen (d > 10) $
+    showString "fromList " . shows (toList o)
+
+readsPrecList :: Read a => ([a] -> b) -> Int -> ReadS b
+readsPrecList fromList d = readParen (d > 10) $ \r -> do
+    ("fromList", s) <- lex r
+    (xs, t) <- reads s
+    return (fromList xs, t)

--- a/Language/Haskell/TH/Desugar/OSet.hs
+++ b/Language/Haskell/TH/Desugar/OSet.hs
@@ -1,0 +1,46 @@
+{- Language/Haskell/TH/Desugar/OSet.hs
+
+(c) Daniel Wagner 2016-2018, Ryan Scott 2019
+-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Language.Haskell.TH.Desugar.OSet
+-- Copyright   :  (C) 2016-2018 Daniel Wagner, 2019 Ryan Scott
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  Ryan Scott
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- An 'OSet' behaves much like a 'S.Set', with all the same asymptotics, but
+-- also remembers the order that values were inserted.
+--
+----------------------------------------------------------------------------
+module Language.Haskell.TH.Desugar.OSet
+    ( OSet
+    -- * Trivial sets
+    , empty, singleton
+    -- * Insertion
+    -- | Conventionts:
+    --
+    -- * The open side of an angle bracket points to an 'OSet'
+    --
+    -- * The pipe appears on the side whose indices take precedence for keys that appear on both sides
+    --
+    -- * The left argument's indices are lower than the right argument's indices
+    , (<|), (|<), (>|), (|>)
+    , (<>|), (|<>)
+    -- * Query
+    , null, size, member, notMember
+    -- * Deletion
+    , delete, filter, (\\), intersection
+    -- * Indexing
+    , Index, findIndex, elemAt
+    -- * List conversions
+    , fromList, toAscList
+    ) where
+
+import qualified Data.Set as S ()
+import Language.Haskell.TH.Desugar.OMapSetUtil
+import Language.Haskell.TH.Desugar.OSet.Internal
+import Prelude hiding (filter, foldr, lookup, null)

--- a/Language/Haskell/TH/Desugar/OSet/Internal.hs
+++ b/Language/Haskell/TH/Desugar/OSet/Internal.hs
@@ -1,0 +1,169 @@
+{- Language/Haskell/TH/Desugar/OSet/Internal.hs
+
+(c) Daniel Wagner 2016-2018, Ryan Scott 2019
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+module Language.Haskell.TH.Desugar.OSet.Internal where
+
+import Control.Monad (guard)
+import Data.Data
+import Data.Foldable (foldl', foldr, toList)
+import Data.Function (on)
+import Data.Map (Map)
+import Language.Haskell.TH.Desugar.OMapSetUtil (Index, Tag, maxTag, minTag, nextHigherTag, nextLowerTag, readsPrecList, showsPrecList)
+import Prelude hiding (filter, foldr, lookup, null)
+import qualified Data.Map as M
+
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Foldable (Foldable, foldMap)
+import Data.Monoid (Monoid(..))
+#endif
+
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
+#endif
+
+data OSet a = OSet !(Map a Tag) !(Map Tag a)
+
+-- | Values appear in insertion order, not ascending order.
+instance Foldable OSet where foldMap f (OSet _ vs) = foldMap f vs
+instance         Eq   a  => Eq   (OSet a) where (==)    = (==)    `on` toList
+instance         Ord  a  => Ord  (OSet a) where compare = compare `on` toList
+instance         Show a  => Show (OSet a) where showsPrec = showsPrecList toList
+instance (Ord a, Read a) => Read (OSet a) where readsPrec = readsPrecList fromList
+instance Ord a => Semigroup (OSet a) where
+  (<>) = (|<>)
+instance Ord a => Monoid (OSet a) where
+  mempty = empty
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
+
+# if __GLASGOW_HASKELL__ >= 708
+deriving instance Typeable OSet
+# else
+deriving instance Typeable1 OSet
+# endif
+
+-- This instance preserves data abstraction at the cost of inefficiency.
+-- We provide limited reflection services for the sake of data abstraction.
+
+instance (Data a, Ord a) => Data (OSet a) where
+  gfoldl f z set = z fromList `f` (toList set)
+  toConstr _     = fromListConstr
+  gunfold k z c  = case constrIndex c of
+    1 -> k (z fromList)
+    _ -> error "gunfold"
+  dataTypeOf _   = oSetDataType
+  dataCast1 f    = gcast1 f
+
+fromListConstr :: Constr
+fromListConstr = mkConstr oSetDataType "fromList" [] Prefix
+
+oSetDataType :: DataType
+oSetDataType = mkDataType "Data.Set.Ordered.Set" [fromListConstr]
+
+infixr 5 <|, |<   -- copy :
+infixl 5 >|, |>
+infixr 6 <>|, |<> -- copy <>
+
+(<|) , (|<)  :: Ord a =>      a -> OSet a -> OSet a
+(>|) , (|>)  :: Ord a => OSet a ->      a -> OSet a
+(<>|), (|<>) :: Ord a => OSet a -> OSet a -> OSet a
+
+v <| o@(OSet ts vs)
+    | v `member` o = o
+    | otherwise    = OSet (M.insert v t ts) (M.insert t v vs) where
+        t = nextLowerTag vs
+
+v |< o = OSet (M.insert v t ts) (M.insert t v vs) where
+    t = nextLowerTag vs
+    OSet ts vs = delete v o
+
+o@(OSet ts vs) |> v
+    | v `member` o = o
+    | otherwise    = OSet (M.insert v t ts) (M.insert t v vs) where
+        t = nextHigherTag vs
+
+o >| v = OSet (M.insert v t ts) (M.insert t v vs) where
+    t = nextHigherTag vs
+    OSet ts vs = delete v o
+
+o <>| o' = unsafeMappend (o \\ o') o'
+o |<> o' = unsafeMappend o (o' \\ o)
+
+-- assumes that ts and ts' have disjoint keys
+unsafeMappend :: Ord a => OSet a -> OSet a -> OSet a
+unsafeMappend (OSet ts vs) (OSet ts' vs')
+    = OSet (M.union tsBumped tsBumped')
+           (M.union vsBumped vsBumped')
+    where
+    bump  = case maxTag vs  of
+        Nothing -> 0
+        Just k  -> -k-1
+    bump' = case minTag vs' of
+        Nothing -> 0
+        Just k  -> -k
+    tsBumped  = fmap (bump +) ts
+    tsBumped' = fmap (bump'+) ts'
+    vsBumped  = (bump +) `M.mapKeysMonotonic` vs
+    vsBumped' = (bump'+) `M.mapKeysMonotonic` vs'
+
+-- | Set difference: @r \\\\ s@ deletes all the values in @s@ from @r@. The
+-- order of @r@ is unchanged.
+(\\) :: Ord a => OSet a -> OSet a -> OSet a
+o@(OSet _ _) \\ o'@(OSet _ vs') = if size o < size o'
+    then filter (`notMember` o') o
+    else foldr delete o vs'
+
+intersection :: Ord a => OSet a -> OSet a -> OSet a
+intersection o o' = filter (`member` o') o
+
+empty :: OSet a
+empty = OSet M.empty M.empty
+
+member, notMember :: Ord a => a -> OSet a -> Bool
+member    v (OSet ts _) = M.member    v ts
+notMember v (OSet ts _) = M.notMember v ts
+
+size :: OSet a -> Int
+size (OSet ts _) = M.size ts
+
+-- the Ord constraint is for compatibility with older (<0.5) versions of
+-- containers
+filter :: Ord a => (a -> Bool) -> OSet a -> OSet a
+filter f (OSet ts vs) = OSet (M.filterWithKey (\v _ -> f v) ts)
+                             (M.filterWithKey (\_ v -> f v) vs)
+
+delete :: Ord a => a -> OSet a -> OSet a
+delete v o@(OSet ts vs) = case M.lookup v ts of
+    Nothing -> o
+    Just t  -> OSet (M.delete v ts) (M.delete t vs)
+
+singleton :: a -> OSet a
+singleton v = OSet (M.singleton v 0) (M.singleton 0 v)
+
+-- | If a value occurs multiple times, only the first occurrence is used.
+fromList :: Ord a => [a] -> OSet a
+fromList = foldl' (|>) empty
+
+null :: OSet a -> Bool
+null (OSet ts _) = M.null ts
+
+findIndex :: Ord a => a -> OSet a -> Maybe Index
+findIndex v (OSet ts vs) = do
+    t <- M.lookup v ts
+    M.lookupIndex t vs
+
+elemAt :: OSet a -> Index -> Maybe a
+elemAt (OSet _ vs) i = do
+    guard (0 <= i && i < M.size vs)
+    return . snd $ M.elemAt i vs
+
+-- | Returns values in ascending order. (Use 'toList' to return them in
+-- insertion order.)
+toAscList :: OSet a -> [a]
+toAscList (OSet ts _) = fmap fst (M.toAscList ts)

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -32,13 +32,13 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
 import Control.Monad.RWS
+import qualified Data.Foldable as F
 import Data.Function (on)
 import Data.List
 import Data.Maybe
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
 #endif
-import qualified Data.Set as S
 #if __GLASGOW_HASKELL__ >= 800
 import qualified Control.Monad.Fail as Fail
 #else
@@ -229,7 +229,7 @@ type Named a = (Name, a)
 reifyInDec :: Name -> [Dec] -> Dec -> Maybe (Named Info)
 reifyInDec n decs (FunD n' _) | n `nameMatches` n' = Just (n', mkVarI n decs)
 reifyInDec n decs (ValD pat _ _)
-  | Just n' <- find (nameMatches n) (S.elems (extractBoundNamesPat pat)) = Just (n', mkVarI n decs)
+  | Just n' <- find (nameMatches n) (F.toList (extractBoundNamesPat pat)) = Just (n', mkVarI n decs)
 #if __GLASGOW_HASKELL__ > 710
 reifyInDec n _    dec@(DataD    _ n' _ _ _ _) | n `nameMatches` n' = Just (n', TyConI dec)
 reifyInDec n _    dec@(NewtypeD _ n' _ _ _ _) | n `nameMatches` n' = Just (n', TyConI dec)

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -47,22 +47,29 @@ library
       template-haskell >= 2.8 && < 2.16,
       containers >= 0.5,
       mtl >= 2.1,
+      semigroups >= 0.16,
       syb >= 0.4,
-      th-abstraction >= 0.2.10,
+      th-abstraction >= 0.2.11,
       th-lift >= 0.6.1,
       th-orphans >= 0.9.1
   default-extensions: TemplateHaskell
-  exposed-modules:    Language.Haskell.TH.Desugar,
-                      Language.Haskell.TH.Desugar.Sweeten,
-                      Language.Haskell.TH.Desugar.Lift,
-                      Language.Haskell.TH.Desugar.Expand,
+  exposed-modules:    Language.Haskell.TH.Desugar
+                      Language.Haskell.TH.Desugar.Expand
+                      Language.Haskell.TH.Desugar.Lift
+                      Language.Haskell.TH.Desugar.OMap
+                      Language.Haskell.TH.Desugar.OMap.Strict
+                      Language.Haskell.TH.Desugar.OSet
                       Language.Haskell.TH.Desugar.Subst
-  other-modules:      Language.Haskell.TH.Desugar.AST,
-                      Language.Haskell.TH.Desugar.Core,
-                      Language.Haskell.TH.Desugar.FV,
-                      Language.Haskell.TH.Desugar.Match,
-                      Language.Haskell.TH.Desugar.Util,
+                      Language.Haskell.TH.Desugar.Sweeten
+  other-modules:      Language.Haskell.TH.Desugar.AST
+                      Language.Haskell.TH.Desugar.Core
+                      Language.Haskell.TH.Desugar.FV
+                      Language.Haskell.TH.Desugar.Match
+                      Language.Haskell.TH.Desugar.OMap.Internal
+                      Language.Haskell.TH.Desugar.OSet.Internal
+                      Language.Haskell.TH.Desugar.OMapSetUtil
                       Language.Haskell.TH.Desugar.Reify
+                      Language.Haskell.TH.Desugar.Util
   default-language:   Haskell2010
   ghc-options:        -Wall
 


### PR DESCRIPTION
There were several places in `th-desugar` that would compute entirely different things depending on the order in which GHC's unique numbers happened to be computed:

* Previously, `toposortTyVarsOf` was performing a topological sort on a graph constructed from the `graphFromEdges` function in the `containers` library, which relies on the `Ord Name` instance to work. The `Ord Name` instance sorts first by the unique value stored in the `Name`, making this instance nondeterministic should its behavior ever leak out to user-facing code.

  In this patch, I `graphFromEdges` component of `toposortTyVarsOf` with `scopedSort`, a deterministic function which mimics the topological sorting without relying on the `Ord Name` instance. `scopedSort`'s implementation is cargo-culted from the function of
  the same name in the GHC source code.
* All functions in `th-desugar` that compute free variables were returning a `Set Name`. This becomes dangerous since other parts of the codebase (in `th-desugar` and `singletons`) call `toList` on these `Set`s of `Name`s, converting them into a list sorted in ascending order by their `Name`s!

  In this patch, I introduce `OMap` and `OSet` data structures that behave like `Map` and `Set`, but remembering the order in which elements were inserted. Their implementations are mostly taken from the `ordered-containers` library. I didn't depend on `ordered-containers` directly since I needed to make some minor modifications (among which are https://github.com/dmwit/ordered-containers/pull/7, https://github.com/dmwit/ordered-containers/pull/8, https://github.com/dmwit/ordered-containers/pull/9, and https://github.com/dmwit/ordered-containers/pull/5) to suit `th-desugar`'s needs, and the maintainer of `ordered-containers` does not appear to be responsive to pull requests.

  I replaced every nondeterministic use of `Map` and `Set` with `OMap` and `OSet`, respectively. Note that not every use of `Map` and `Set` needs to be replaced—for instance, the code in `Language.Haskell.TH.Desugar.Subst` uses `Map`s to represent substitutions, but this is fine, since the internal order of the `Map`s is never leaked to the user.

This diff appears large, but most of the modifications are routine changes brought about by switching data structures. Now that these changes are in place, we can finally run the `th-desugar` test suite with `-dunique-increment=-1` and have it still pass! Hooray!

Fixes #112.