### PR TITLE
Adapt to MonadFail-related changes in base-4.13

### DIFF
--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -46,6 +46,7 @@ import Language.Haskell.TH.Desugar.OSet (OSet)
 import Language.Haskell.TH.Syntax
 
 import Control.Monad ( replicateM )
+import qualified Control.Monad.Fail as Fail
 import Data.Foldable
 import Data.Generics hiding ( Fixity )
 import Data.Traversable
@@ -115,8 +116,8 @@ stripPlainTV_maybe (PlainTV n) = Just n
 stripPlainTV_maybe _           = Nothing
 
 -- | Report that a certain TH construct is impossible
-impossible :: Monad q => String -> q a
-impossible err = fail (err ++ "\n    This should not happen in Haskell.\n    Please email rae@cs.brynmawr.edu with your code if you see this.")
+impossible :: Fail.MonadFail q => String -> q a
+impossible err = Fail.fail (err ++ "\n    This should not happen in Haskell.\n    Please email rae@cs.brynmawr.edu with your code if you see this.")
 
 -- | Convert a 'TyVarBndr' into a 'Type', dropping the kind signature
 -- (if it has one).
@@ -440,9 +441,9 @@ mapMaybeM f (x:xs) = do
     Nothing -> ys
     Just z  -> z : ys
 
-expectJustM :: Monad m => String -> Maybe a -> m a
+expectJustM :: Fail.MonadFail m => String -> Maybe a -> m a
 expectJustM _   (Just x) = return x
-expectJustM err Nothing  = fail err
+expectJustM err Nothing  = Fail.fail err
 
 firstMatch :: (a -> Maybe b) -> [a] -> Maybe b
 firstMatch f xs = listToMaybe $ mapMaybe f xs

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -46,12 +46,14 @@ library
       ghc-prim,
       template-haskell >= 2.8 && < 2.16,
       containers >= 0.5,
+      fail == 4.9.*,
       mtl >= 2.1,
       semigroups >= 0.16,
       syb >= 0.4,
       th-abstraction >= 0.2.11,
       th-lift >= 0.6.1,
-      th-orphans >= 0.9.1
+      th-orphans >= 0.13.7,
+      transformers-compat >= 0.6.3
   default-extensions: TemplateHaskell
   exposed-modules:    Language.Haskell.TH.Desugar
                       Language.Haskell.TH.Desugar.Expand


### PR DESCRIPTION
`base-4.13` removes the `fail` method from `Monad`, leaving it exclusively as a method of `MonadFail` (which is now exported from the `Prelude`). Some updates to `th-desugar` are required in order to continue building with these changes:

* GHC 8.8 deprecates the `MonadFailDesugaring` extension (since its effects are always enabled), and furthermore, `MonadFailDesugaring` is no longer enabled by default. Therefore, when desugaring failable pattern matches in `do`-notation, we should always use `MonadFail.fail` (which happens to be the same thing as `Prelude.fail` now).
* Certain functions that call `fail` only have `Monad` constraints, which need to be strengthened to `MonadFail` constraints. To allow these functions to have the same API across different versions of CPP, I depend on the lightweight `fail` compatibility package so that I can always use `MonadFail` without CPP.
* The aforementioned functions are often instantiated to be `DsMonad` which, prior to `template-haskell-2.11`, did not have `MonadFail` as a superclass. To keep the API as consistent as possible across different versions of GHC, an explicit `MonadFail` superclass constraint was added to `DsMonad`. This requires incurring a dependency on the lightweight `transformers-compat` package (which provides orphan `MonadFail` instances for monad transformer types) to ensure that `MonadFail` instances for things like `ReaderT`, `StateT`, etc. are always available, as `th-desugar` assumes this at various points in the code. I also needed to tighten the lower version bound on `th-orphans` in order to ensure that an orphan `MonadFail Q` instance is available.