### PR TITLE
Add `Maybe [DTyVarBndr]` fields to `DInstanceD`/`DStandaloneDerivD` (#117)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,12 @@ Version 1.10
     now that each `DTySynEqn` contains the same `Name`.
   * There is now a field of type `Maybe [DTyVarBndr]` in the `DRuleP`
     constructor to represent bound type variables in `RULES` (if present).
+* Add a field of type `Maybe [DTyVarBndr]` to `DInstanceD` and
+  `DStandaloneDerivD` for optionally quantifying type variables explicitly.
+  If supplied with a `Just`, this sweetens the instance type to use a `ForallT`
+  to represent the explicit quantification. This trick is not supported for
+  `InstanceD` on GHC 8.0 and for `StandaloneDerivD` on GHC 7.10 or 8.0, so be
+  aware of this limitation if you supply `Just` for this field.
 * Add support for desugaring implicit params. This does not involve any changes
   to the `th-desugar` AST, as:
   * `(?x :: a) => ...` is desugared to `IP "x" a => ...`.

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -91,7 +91,7 @@ data DDec = DLetDec DLetDec
           | DDataD NewOrData DCxt Name [DTyVarBndr] (Maybe DKind) [DCon] [DDerivClause]
           | DTySynD Name [DTyVarBndr] DType
           | DClassD DCxt Name [DTyVarBndr] [FunDep] [DDec]
-          | DInstanceD (Maybe Overlap) DCxt DType [DDec]
+          | DInstanceD (Maybe Overlap) (Maybe [DTyVarBndr]) DCxt DType [DDec]
           | DForeignD DForeign
           | DOpenTypeFamilyD DTypeFamilyHead
           | DClosedTypeFamilyD DTypeFamilyHead [DTySynEqn]
@@ -100,7 +100,7 @@ data DDec = DLetDec DLetDec
                        [DCon] [DDerivClause]
           | DTySynInstD DTySynEqn
           | DRoleAnnotD Name [Role]
-          | DStandaloneDerivD (Maybe DDerivStrategy) DCxt DType
+          | DStandaloneDerivD (Maybe DDerivStrategy) (Maybe [DTyVarBndr]) DCxt DType
           | DDefaultSigD Name DType
           | DPatSynD Name PatSynArgs DPatSynDir DPat
           | DPatSynSigD Name DPatSynType

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -709,10 +709,10 @@ dsDec (ClassD cxt n tvbs fds decs) =
                      <*> pure fds <*> dsDecs decs)
 #if __GLASGOW_HASKELL__ >= 711
 dsDec (InstanceD over cxt ty decs) =
-  (:[]) <$> (DInstanceD <$> pure over <*> dsCxt cxt <*> dsType ty <*> dsDecs decs)
+  (:[]) <$> (DInstanceD over Nothing <$> dsCxt cxt <*> dsType ty <*> dsDecs decs)
 #else
 dsDec (InstanceD cxt ty decs) =
-  (:[]) <$> (DInstanceD <$> pure Nothing <*> dsCxt cxt <*> dsType ty <*> dsDecs decs)
+  (:[]) <$> (DInstanceD Nothing Nothing <$> dsCxt cxt <*> dsType ty <*> dsDecs decs)
 #endif
 dsDec d@(SigD {}) = dsTopLevelLetDec d
 dsDec (ForeignD f) = (:[]) <$> (DForeignD <$> dsForeign f)
@@ -781,10 +781,11 @@ dsDec (PatSynD n args dir pat) = do
   return [DPatSynD n args dir' pat']
 dsDec (PatSynSigD n ty) = (:[]) <$> (DPatSynSigD n <$> dsType ty)
 dsDec (StandaloneDerivD mds cxt ty) =
-  (:[]) <$> (DStandaloneDerivD <$> mapM dsDerivStrategy mds <*> dsCxt cxt <*> dsType ty)
+  (:[]) <$> (DStandaloneDerivD <$> mapM dsDerivStrategy mds
+                               <*> pure Nothing <*> dsCxt cxt <*> dsType ty)
 #else
 dsDec (StandaloneDerivD cxt ty) =
-  (:[]) <$> (DStandaloneDerivD Nothing <$> dsCxt cxt <*> dsType ty)
+  (:[]) <$> (DStandaloneDerivD Nothing Nothing <$> dsCxt cxt <*> dsType ty)
 #endif
 dsDec (DefaultSigD n ty) = (:[]) <$> (DDefaultSigD n <$> dsType ty)
 #endif

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -116,6 +116,7 @@ decToTH (DInstanceD over mtvbs _cxt _ty decs) =
 #if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
                                 ([], DForallT _tvbs _cxt _ty)
 #else
+                                -- See #117
                                 error $ "Explicit foralls in instance declarations "
                                      ++ "are broken on GHC 8.0."
 #endif
@@ -173,6 +174,7 @@ decToTH (DStandaloneDerivD mds mtvbs _cxt _ty) =
 #if __GLASGOW_HASKELL__ < 710 || __GLASGOW_HASKELL__ >= 802
                                 ([], DForallT _tvbs _cxt _ty)
 #else
+                                -- See #117
                                 error $ "Explicit foralls in standalone deriving declarations "
                                      ++ "are broken on GHC 7.10 and 8.0."
 #endif

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -107,12 +107,17 @@ decToTH (DDataD Newtype cxt n tvbs _mk [con] derivings) =
 decToTH (DTySynD n tvbs ty) = [TySynD n (map tvbToTH tvbs) (typeToTH ty)]
 decToTH (DClassD cxt n tvbs fds decs) =
   [ClassD (cxtToTH cxt) n (map tvbToTH tvbs) fds (decsToTH decs)]
-#if __GLASGOW_HASKELL__ >= 711
-decToTH (DInstanceD over cxt ty decs) =
-  [InstanceD over (cxtToTH cxt) (typeToTH ty) (decsToTH decs)]
+decToTH (DInstanceD over mtvbs _cxt _ty decs) =
+  [instanceDToTH over cxt' ty' decs]
+  where
+  (cxt', ty') = case mtvbs of
+                  Nothing    -> (_cxt, _ty)
+                  Just _tvbs ->
+#if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
+                                ([], DForallT _tvbs _cxt _ty)
 #else
-decToTH (DInstanceD _ cxt ty decs) =
-  [InstanceD (cxtToTH cxt) (typeToTH ty) (decsToTH decs)]
+                                error $ "Explicit foralls in instance declarations "
+                                     ++ "are broken on GHC 8.0."
 #endif
 decToTH (DForeignD f) = [ForeignD (foreignToTH f)]
 #if __GLASGOW_HASKELL__ > 710
@@ -159,18 +164,22 @@ decToTH (DClosedTypeFamilyD (DTypeFamilyHead n tvbs frs _ann) eqns) =
 #endif
 decToTH (DRoleAnnotD n roles) = [RoleAnnotD n roles]
 #endif
+decToTH (DStandaloneDerivD mds mtvbs _cxt _ty) =
+  [standaloneDerivDToTH mds cxt' ty']
+  where
+  (cxt', ty') = case mtvbs of
+                  Nothing    -> (_cxt, _ty)
+                  Just _tvbs ->
+#if __GLASGOW_HASKELL__ < 710 || __GLASGOW_HASKELL__ >= 802
+                                ([], DForallT _tvbs _cxt _ty)
+#else
+                                error $ "Explicit foralls in standalone deriving declarations "
+                                     ++ "are broken on GHC 7.10 and 8.0."
+#endif
 #if __GLASGOW_HASKELL__ < 709
-decToTH (DStandaloneDerivD {}) =
-  error "Standalone deriving supported only in GHC 7.10+"
 decToTH (DDefaultSigD {})      =
   error "Default method signatures supported only in GHC 7.10+"
 #else
-decToTH (DStandaloneDerivD _mds cxt ty) =
-  [StandaloneDerivD
-#if __GLASGOW_HASKELL__ >= 801
-    (fmap derivStrategyToTH _mds)
-#endif
-    (cxtToTH cxt) (typeToTH ty)]
 decToTH (DDefaultSigD n ty)        = [DefaultSigD n (typeToTH ty)]
 #endif
 #if __GLASGOW_HASKELL__ >= 801
@@ -323,6 +332,26 @@ conToTH (DCon tvbs cxt n fields rty)
 
     con' :: Con
     con' = conToTH $ DCon [] [] n fields rty
+#endif
+
+instanceDToTH :: Maybe Overlap -> DCxt -> DType -> [DDec] -> Dec
+instanceDToTH _over cxt ty decs =
+  InstanceD
+#if __GLASGOW_HASKELL__ >= 800
+            _over
+#endif
+            (cxtToTH cxt) (typeToTH ty) (decsToTH decs)
+
+standaloneDerivDToTH :: Maybe DDerivStrategy -> DCxt -> DType -> Dec
+#if __GLASGOW_HASKELL__ >= 710
+standaloneDerivDToTH _mds cxt ty =
+  StandaloneDerivD
+#if __GLASGOW_HASKELL__ >= 802
+                   (fmap derivStrategyToTH _mds)
+#endif
+                   (cxtToTH cxt) (typeToTH ty)
+#else
+standaloneDerivDToTH _ _ _ = error "Standalone deriving supported only in GHC 7.10+"
 #endif
 
 foreignToTH :: DForeign -> Foreign

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -12,6 +12,9 @@ rae@cs.brynmawr.edu
 #if __GLASGOW_HASKELL__ >= 707
 {-# LANGUAGE RoleAnnotations #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 710
+{-# LANGUAGE DeriveAnyClass #-}
+#endif
 
 {-# OPTIONS_GHC -fno-warn-orphans -fno-warn-name-shadowing #-}
 
@@ -43,6 +46,13 @@ $(S.dectest14)
 
 #if __GLASGOW_HASKELL__ >= 710
 $(S.dectest15)
+#endif
+
+#if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
+$(S.dectest16)
+#endif
+#if __GLASGOW_HASKELL__ >= 802
+$(S.dectest17)
 #endif
 
 $(fmap unqualify S.instance_test)

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -12,6 +12,9 @@ rae@cs.brynmawr.edu
 #if __GLASGOW_HASKELL__ >= 707
 {-# LANGUAGE RoleAnnotations #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 710
+{-# LANGUAGE DeriveAnyClass #-}
+#endif
 #if __GLASGOW_HASKELL__ >= 801
 {-# LANGUAGE DerivingStrategies #-}
 #endif
@@ -72,6 +75,13 @@ $(dsDecSplice S.dectest14)
 
 #if __GLASGOW_HASKELL__ >= 710
 $(dsDecSplice S.dectest15)
+#endif
+
+#if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
+$(return $ decsToTH [S.ds_dectest16])
+#endif
+#if __GLASGOW_HASKELL__ >= 802
+$(return $ decsToTH [S.ds_dectest17])
 #endif
 
 $(do decs <- S.rec_sel_test

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -423,6 +423,35 @@ dectest15 = [d| infixl 5 :**:, :&&:, :^^:, `ActuallyPrefix`
                   (:^^:) :: Int -> Int -> Int -> InfixGADT Int
                   (:!!:) :: Char -> Char -> InfixGADT Char |]
 
+class ExCls a
+data ExData1 a
+data ExData2 a
+
+ds_dectest16 = DInstanceD Nothing (Just [DPlainTV (mkName "a")]) []
+                (DConT ''ExCls `DAppT`
+                  (DConT ''ExData1 `DAppT` DVarT (mkName "a"))) []
+dectest16 :: Q [Dec]
+dectest16 = return [ InstanceD
+#if __GLASGOW_HASKELL__ >= 800
+                       Nothing
+#endif
+                       [] (ForallT [PlainTV (mkName "a")] []
+                                   (ConT ''ExCls `AppT`
+                                     (ConT ''ExData1 `AppT` VarT (mkName "a")))) [] ]
+ds_dectest17 = DStandaloneDerivD Nothing (Just [DPlainTV (mkName "a")]) []
+                (DConT ''ExCls `DAppT`
+                  (DConT ''ExData2 `DAppT` DVarT (mkName "a")))
+#if __GLASGOW_HASKELL__ >= 710
+dectest17 :: Q [Dec]
+dectest17 = return [ StandaloneDerivD
+#if __GLASGOW_HASKELL__ >= 802
+                       Nothing
+#endif
+                       [] (ForallT [PlainTV (mkName "a")] []
+                                   (ConT ''ExCls `AppT`
+                                     (ConT ''ExData2 `AppT` VarT (mkName "a")))) ]
+#endif
+
 instance_test = [d| instance (Show a, Show b) => Show (a -> b) where
                        show _ = "function" |]
 


### PR DESCRIPTION
This resolves #117 by implementing the trick described in that issue. Alas, this trick does not work on all versions of GHC that `th-desugar` currently supports, so some CPP hackery is employed to produce slightly more sensible error messages in the event that the trick is used on incompatible GHC versions.