### PR TITLE
Desugar tuple sections to lambda expressions (#121)

### DIFF
--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -8,7 +8,7 @@ rae@cs.brynmawr.edu
              RankNTypes, TypeFamilies,
              DataKinds, ConstraintKinds, PolyKinds, MultiParamTypeClasses,
              FlexibleInstances, ExistentialQuantification,
-             ScopedTypeVariables, GADTs, ViewPatterns #-}
+             ScopedTypeVariables, GADTs, ViewPatterns, TupleSections #-}
 {-# OPTIONS -fno-warn-incomplete-patterns -fno-warn-overlapping-patterns
             -fno-warn-unused-matches -fno-warn-type-defaults
             -fno-warn-missing-signatures -fno-warn-unused-do-bind
@@ -135,6 +135,9 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
 #if __GLASGOW_HASKELL__ >= 807
              , "implicit_params" ~: $test49_implicit_params @=? $(dsSplice test49_implicit_params)
              , "vka"             ~: $test50_vka             @=? $(dsSplice test50_vka)
+#endif
+#if __GLASGOW_HASKELL__ >= 809
+             , "tuple_sections"  ~: $test51_tuple_sections  @=? $(dsSplice test51_tuple_sections)
 #endif
              ]
 

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -9,7 +9,8 @@ rae@cs.brynmawr.edu
              ScopedTypeVariables, RankNTypes, TypeFamilies, ImpredicativeTypes,
              DataKinds, PolyKinds, GADTs, MultiParamTypeClasses,
              FunctionalDependencies, FlexibleInstances, StandaloneDeriving,
-             DefaultSignatures, ConstraintKinds, GADTs, ViewPatterns #-}
+             DefaultSignatures, ConstraintKinds, GADTs, ViewPatterns,
+             TupleSections #-}
 
 #if __GLASGOW_HASKELL__ >= 711
 {-# LANGUAGE TypeApplications #-}
@@ -272,6 +273,17 @@ test49_implicit_params = [| let f :: (?x :: Int, ?y :: Int) => (Int, Int)
 test50_vka = [| let hrefl :: (:~~:) @Bool @Bool 'True 'True
                     hrefl = HRefl
                 in hrefl |]
+#endif
+
+#if __GLASGOW_HASKELL__ >= 809
+test51_tuple_sections =
+  [| let f1 :: String -> Char -> (String, Int, Char)
+         f1 = (,5,)
+
+         f2 :: String -> Char -> (# String, Int, Char #)
+         f2 = (#,5,#)
+     in case (#,#) (f1 "a" 'a') (f2 "b" 'b') of
+          (#,#) ((,,) _ a _) ((#,,#) _ b _) -> a + b |]
 #endif
 
 type family TFExpand x
@@ -681,5 +693,8 @@ test_exprs = [ test1_sections
 #if __GLASGOW_HASKELL__ >= 807
              , test49_implicit_params
              , test50_vka
+#endif
+#if __GLASGOW_HASKELL__ >= 809
+             , test51_tuple_sections
 #endif
              ]


### PR DESCRIPTION
GHC HEAD grants the power to represent tuple sections in the TH AST. Unfortunately, this required a breaking change to the type signatures of `TupE` and `UnboxedTupE`, which requires `th-desugar` to adapt. While we're at it, let's desugar tuple sections to lambda expressions (e.g., `(,5)` becomes `\ts -> (,) ts 5`).

Fixes #121.