### PR TITLE
Fix #123 by removing SYB code from hot loops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,8 @@ Version 1.10
   elements were inserted. A consequence of this change is that it fixes a bug
   that causes free variables to be computed in different orders depending on
   which unique numbers GHC happened to generate internally.
+* Substition and type synonym expansion are now more efficient by avoiding
+  the use of `syb` in inner loops.
 
 Version 1.9
 -----------

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -25,7 +25,7 @@ data DExp = DVarE Name
           | DLetE [DLetDec] DExp
           | DSigE DExp DType
           | DStaticE DExp
-          deriving (Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Typeable, Data, Generic)
 
 
 -- | Corresponds to TH's @Pat@ type.
@@ -36,7 +36,7 @@ data DPat = DLitP Lit
           | DBangP DPat
           | DSigP DPat DType
           | DWildP
-          deriving (Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @Type@ type, used to represent
 -- types and kinds.
@@ -49,7 +49,7 @@ data DType = DForallT [DTyVarBndr] DCxt DType
            | DArrowT
            | DLitT TyLit
            | DWildCardT
-           deriving (Show, Typeable, Data, Generic)
+           deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Kinds are types. Corresponds to TH's @Kind@
 type DKind = DType
@@ -63,15 +63,15 @@ type DCxt = [DPred]
 -- | Corresponds to TH's @TyVarBndr@
 data DTyVarBndr = DPlainTV Name
                 | DKindedTV Name DKind
-                deriving (Show, Typeable, Data, Generic)
+                deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @Match@ type.
 data DMatch = DMatch DPat DExp
-  deriving (Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @Clause@ type.
 data DClause = DClause [DPat] DExp
-  deriving (Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Declarations as used in a @let@ statement.
 data DLetDec = DFunD Name [DClause]
@@ -79,7 +79,7 @@ data DLetDec = DFunD Name [DClause]
              | DSigD Name DType
              | DInfixD Fixity Name
              | DPragmaD DPragma
-             deriving (Show, Typeable, Data, Generic)
+             deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Is it a @newtype@ or a @data@ type?
 data NewOrData = Newtype
@@ -104,7 +104,7 @@ data DDec = DLetDec DLetDec
           | DDefaultSigD Name DType
           | DPatSynD Name PatSynArgs DPatSynDir DPat
           | DPatSynSigD Name DPatSynType
-          deriving (Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Typeable, Data, Generic)
 
 #if __GLASGOW_HASKELL__ < 711
 data Overlap = Overlappable | Overlapping | Overlaps | Incoherent
@@ -115,7 +115,7 @@ data Overlap = Overlappable | Overlapping | Overlaps | Incoherent
 data DPatSynDir = DUnidir              -- ^ @pattern P x {<-} p@
                 | DImplBidir           -- ^ @pattern P x {=} p@
                 | DExplBidir [DClause] -- ^ @pattern P x {<-} p where P x = e@
-                deriving (Show, Typeable, Data, Generic)
+                deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's 'PatSynType' type
 type DPatSynType = DType
@@ -126,19 +126,19 @@ data PatSynArgs
   = PrefixPatSyn [Name]        -- ^ @pattern P {x y z} = p@
   | InfixPatSyn Name Name      -- ^ @pattern {x P y} = p@
   | RecordPatSyn [Name]        -- ^ @pattern P { {x,y,z} } = p@
-  deriving (Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Typeable, Data, Generic)
 #endif
 
 -- | Corresponds to TH's 'TypeFamilyHead' type
 data DTypeFamilyHead = DTypeFamilyHead Name [DTyVarBndr] DFamilyResultSig
                                        (Maybe InjectivityAnn)
-                     deriving (Show, Typeable, Data, Generic)
+                     deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's 'FamilyResultSig' type
 data DFamilyResultSig = DNoSig
                       | DKindSig DKind
                       | DTyVarSig DTyVarBndr
-                      deriving (Show, Typeable, Data, Generic)
+                      deriving (Eq, Show, Typeable, Data, Generic)
 
 #if __GLASGOW_HASKELL__ <= 710
 data InjectivityAnn = InjectivityAnn Name [Name]
@@ -162,13 +162,13 @@ data InjectivityAnn = InjectivityAnn Name [Name]
 -- * A 'DCon' always has an explicit return type.
 data DCon = DCon [DTyVarBndr] DCxt Name DConFields
                  DType  -- ^ The GADT result type
-          deriving (Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | A list of fields either for a standard data constructor or a record
 -- data constructor.
 data DConFields = DNormalC DDeclaredInfix [DBangType]
                 | DRecC [DVarBangType]
-                deriving (Show, Typeable, Data, Generic)
+                deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | 'True' if a constructor is declared infix. For normal ADTs, this means
 -- that is was written in infix style. For example, both of the constructors
@@ -241,7 +241,7 @@ data Bang = Bang SourceUnpackedness SourceStrictness
 -- | Corresponds to TH's @Foreign@ type.
 data DForeign = DImportF Callconv Safety String Name DType
               | DExportF Callconv String Name DType
-              deriving (Show, Typeable, Data, Generic)
+              deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @Pragma@ type.
 data DPragma = DInlineP Name Inline RuleMatch Phases
@@ -251,16 +251,16 @@ data DPragma = DInlineP Name Inline RuleMatch Phases
              | DAnnP AnnTarget DExp
              | DLineP Int String
              | DCompleteP [Name] (Maybe Name)
-             deriving (Show, Typeable, Data, Generic)
+             deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @RuleBndr@ type.
 data DRuleBndr = DRuleVar Name
                | DTypedRuleVar Name DType
-               deriving (Show, Typeable, Data, Generic)
+               deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @TySynEqn@ type (to store type family equations).
 data DTySynEqn = DTySynEqn (Maybe [DTyVarBndr]) DType DType
-               deriving (Show, Typeable, Data, Generic)
+               deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @Info@ type.
 data DInfo = DTyConI DDec (Maybe [DInstanceDec])
@@ -273,17 +273,17 @@ data DInfo = DTyConI DDec (Maybe [DInstanceDec])
                -- ^ The @Int@ is the arity; the @Bool@ is whether this tycon
                -- is unlifted.
            | DPatSynI Name DPatSynType
-           deriving (Show, Typeable, Data, Generic)
+           deriving (Eq, Show, Typeable, Data, Generic)
 
 type DInstanceDec = DDec -- ^ Guaranteed to be an instance declaration
 
 -- | Corresponds to TH's @DerivClause@ type.
 data DDerivClause = DDerivClause (Maybe DDerivStrategy) DCxt
-                  deriving (Show, Typeable, Data, Generic)
+                  deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Corresponds to TH's @DerivStrategy@ type.
 data DDerivStrategy = DStockStrategy     -- ^ A \"standard\" derived instance
                     | DAnyclassStrategy  -- ^ @-XDeriveAnyClass@
                     | DNewtypeStrategy   -- ^ @-XGeneralizedNewtypeDeriving@
                     | DViaStrategy DType -- ^ @-XDerivingVia@
-                    deriving (Show, Typeable, Data, Generic)
+                    deriving (Eq, Show, Typeable, Data, Generic)

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -1395,7 +1395,7 @@ applyDType = foldl apply
 data DTypeArg
   = DTANormal DType
   | DTyArg DKind
-  deriving (Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Typeable, Data, Generic)
 
 -- | Desugar a 'TypeArg'.
 dsTypeArg :: DsMonad q => TypeArg -> q DTypeArg

--- a/Language/Haskell/TH/Desugar/Subst.hs
+++ b/Language/Haskell/TH/Desugar/Subst.hs
@@ -23,11 +23,9 @@ module Language.Haskell.TH.Desugar.Subst (
   IgnoreKinds(..), matchTy
   ) where
 
+import Data.List
 import qualified Data.Map as M
 import qualified Data.Set as S
-
-import Data.Generics
-import Data.List
 
 import Language.Haskell.TH.Desugar.AST
 import Language.Haskell.TH.Syntax
@@ -85,7 +83,7 @@ substTvb vars (DKindedTV n k) = do
 unionSubsts :: DSubst -> DSubst -> Maybe DSubst
 unionSubsts a b =
   let shared_key_set = M.keysSet a `S.intersection` M.keysSet b
-      matches_up     = S.foldr (\name -> ((a M.! name) `geq` (b M.! name) &&))
+      matches_up     = S.foldr (\name -> ((a M.! name) == (b M.! name) &&))
                                True shared_key_set
   in
   if matches_up then return (a `M.union` b) else Nothing

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -289,7 +289,7 @@ unfoldType = go []
 data TypeArg
   = TANormal Type
   | TyArg Kind
-  deriving (Show, Typeable, Data)
+  deriving (Eq, Show, Typeable, Data)
 
 -- | Apply one 'Type' to a list of arguments.
 applyType :: Type -> [TypeArg] -> Type

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -49,7 +49,6 @@ import Control.Monad
 import Control.Applicative
 #endif
 
-import Data.Generics ( geq )
 import Data.Function ( on )
 import qualified Data.Map as M
 import Data.Proxy
@@ -445,6 +444,14 @@ local_reifications = $(do decs <- reifyDecs
                           let m_infos' = assumeStarT m_infos
                           ListE <$> mapM (Syn.lift . show) (unqualify m_infos'))
 
+type T123G = Either () ()
+type T123F = Either T123G T123G
+type T123E = Either T123F T123F
+type T123D = Either T123E T123E
+type T123C = Either T123D T123D
+type T123B = Either T123C T123C
+type T123A = Either T123B T123B
+
 $reifyDecs
 
 $(return [])  -- somehow, this is necessary to get the staging correct for the
@@ -504,7 +511,13 @@ test_matchTy =
 
      -- GHC 7.6 uses containers-0.5.0.0 which doesn't have a good Data instance
      -- for Map. So we have to convert to lists before comparing.
-    eq = geq `on` fmap M.toList
+    eq = (==) `on` fmap M.toList
+
+-- Test that type synonym expansion is efficient
+test_t123 :: ()
+test_t123 =
+  $(do _ <- expand (DConT ''T123A)
+       [| () |])
 
 main :: IO ()
 main = hspec $ do


### PR DESCRIPTION
`L.H.T.Desugar.Expand` was using code from `syb` in a frequently accessed loop (`expand_con.go`), which is the immediate cause of the slowness observed in #123. This patch replaces this `syb` code with a more verbose—but much more efficient—hand-written traversal. The net benefit of doing this is that the program in #123 now compiles in less than 1 second.

While I was in town, I noticed that there were some places in `th-desugar` that called `geq` when a simple `(==)` would have sufficed. This requires deriving `Eq` instances for various data types, but given that `syb` has been observed to introduce slowness, I think these extra instances are justified.

Fixes #123.