### PR TITLE
Support visible dependent quantification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,45 @@
 `th-desugar` release notes
 ==========================
 
+Version 1.11 [????.??.??]
+-------------------------
+* Support GHC 8.10.
+* Add support for visible dependent quantification. As part of this change,
+  the way `th-desugar` represents `forall` and constraint types has been
+  overhauled:
+  * The existing `DForallT` constructor has been split into two smaller
+    constructors:
+
+    ```diff
+     data DType
+       = ...
+    -  | DForallT [DTyVarBndr] DCxt DType
+    +  | DForallT ForallVisFlag [DTyVarBndr] DType
+    +  | DConstrainedT DCxt DType
+       | ...
+
+    +data ForallVisFlag
+    +  = ForallVis
+    +  | ForallInvis
+    ```
+
+    The previous design combined `forall`s and constraints into a single
+    constructor, while the new design puts them in distinct constructors
+    `DForallT` and `DConstrainedT`, respectively. The new `DForallT`
+    constructor also has a `ForallVisFlag` field to distinguish invisible
+    `forall`s (e.g., `forall a. a`) from visible `forall`s (e.g.,
+    `forall a -> a`).
+  * The `unravel` function has been renamed to `unravelDType` and now returns
+    `(DFunArgs, DType)`, where `DFunArgs` is a data type that represents
+    the possible arguments in a function type (see the Haddocks for `DFunArgs`
+    for more details). There is also an `unravelDType` counterpart for `Type`s
+    named `unravelType`, complete with its own `FunArgs` data type.
+
+    `{D}FunArgs` also have some supporting operations, including
+    `filter{D}VisFunArgs` (to obtain only the visible arguments) and
+    `ravel{D}Type` (to construct a function type using `{D}FunArgs` and
+    a return `{D}Type`).
+
 Version 1.10
 ------------
 * Support GHC 8.8. Drop support for GHC 7.6.

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -23,7 +23,8 @@ rae@cs.brynmawr.edu
 
 module Language.Haskell.TH.Desugar (
   -- * Desugared data types
-  DExp(..), DLetDec(..), DPat(..), DType(..), DKind, DCxt, DPred,
+  DExp(..), DLetDec(..), DPat(..),
+  DType(..), ForallVisFlag(..), DKind, DCxt, DPred,
   DTyVarBndr(..), DMatch(..), DClause(..), DDec(..),
   DDerivClause(..), DDerivStrategy(..), DPatSynDir(..), DPatSynType,
   Overlap(..), PatSynArgs(..), NewOrData(..),
@@ -97,8 +98,14 @@ module Language.Haskell.TH.Desugar (
 #if __GLASGOW_HASKELL__ >= 800
   bindIP,
 #endif
-  unravel, conExistentialTvbs, mkExtraDKindBinders,
+  conExistentialTvbs, mkExtraDKindBinders,
   dTyVarBndrToDType, toposortTyVarsOf,
+
+  -- ** 'FunArgs' and 'VisFunArg'
+  FunArgs(..), VisFunArg(..), filterVisFunArgs, ravelType, unravelType,
+
+  -- ** 'DFunArgs' and 'DVisFunArg'
+  DFunArgs(..), DVisFunArg(..), filterDVisFunArgs, ravelDType, unravelDType,
 
   -- ** 'TypeArg'
   TypeArg(..), applyType, filterTANormals, unfoldType,
@@ -242,7 +249,7 @@ getRecordSelectors arg_ty cons = merge_let_decs `fmap` concatMapM get_record_sel
             con_ex_tvbs <- conExistentialTvbs arg_ty con
             let con_univ_tvbs  = deleteFirstsBy ((==) `on` dtvbName) con_tvbs con_ex_tvbs
                 con_ex_tvb_set = OS.fromList $ map dtvbName con_ex_tvbs
-                forall'        = DForallT con_univ_tvbs []
+                forall'        = DForallT ForallInvis con_univ_tvbs
                 num_pats       = length fields
             return $ concat
               [ [ DSigD name (forall' $ DArrowT `DAppT` con_ret_ty `DAppT` field_ty)

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -138,6 +138,10 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Prelude hiding ( exp )
 
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative
+#endif
+
 -- | This class relates a TH type with its th-desugar type and allows
 -- conversions back and forth. The functional dependency goes only one
 -- way because `Type` and `Kind` are type synonyms, but they desugar

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -13,6 +13,7 @@ module Language.Haskell.TH.Desugar.AST where
 import Data.Data hiding (Fixity)
 import GHC.Generics hiding (Fixity)
 import Language.Haskell.TH
+import Language.Haskell.TH.Desugar.Util (ForallVisFlag)
 
 -- | Corresponds to TH's @Exp@ type. Note that @DLamE@ takes names, not patterns.
 data DExp = DVarE Name
@@ -40,7 +41,8 @@ data DPat = DLitP Lit
 
 -- | Corresponds to TH's @Type@ type, used to represent
 -- types and kinds.
-data DType = DForallT [DTyVarBndr] DCxt DType
+data DType = DForallT ForallVisFlag [DTyVarBndr] DType
+           | DConstrainedT DCxt DType
            | DAppT DType DType
            | DAppKindT DType DKind
            | DSigT DType DKind

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -1727,9 +1727,4 @@ For sweetening:
 * For all other cases, just straightforwardly sweeten
   `DForallT DForallInvis tvbs ty` to `ForallT tvbs [] ty` and
   `DConstrainedT ctxt ty` to `ForallT [] ctxt ty`.
-
-One gotcha of this specification is the th-desugar roundtripping will turn the
-type `() => a` into `forall. () => a`. In practice, Template Haskell won't
-let you do anything bad with this due to the sorts of issues documented in
-GHC #16396.
 -}

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -826,7 +826,12 @@ mkExtraKindBinders =
 
 -- | Like mkExtraDKindBinders, but assumes kind synonyms have been expanded.
 mkExtraDKindBinders' :: Quasi q => DKind -> q [DTyVarBndr]
-mkExtraDKindBinders' = mkExtraKindBindersGeneric unravel DKindedTV
+mkExtraDKindBinders' =
+  mkExtraKindBindersGeneric unravelDType filterDVisFunArgs DKindedTV elim_dvfa
+  where
+    elim_dvfa :: (DTyVarBndr -> r) -> (DKind -> r) -> DVisFunArg -> r
+    elim_dvfa dep _    (DVisFADep tvb) = dep tvb
+    elim_dvfa _   anon (DVisFAAnon k)  = anon k
 
 #if __GLASGOW_HASKELL__ > 710
 -- | Desugar a @FamilyResultSig@
@@ -1143,7 +1148,8 @@ dsClauses n clauses@(Clause outer_pats _ _ : _) = do
 
 -- | Desugar a type
 dsType :: DsMonad q => Type -> q DType
-dsType (ForallT tvbs preds ty) = DForallT <$> mapM dsTvb tvbs <*> dsCxt preds <*> dsType ty
+dsType (ForallT tvbs preds ty) =
+  mkDForallConstrainedT ForallInvis <$> mapM dsTvb tvbs <*> dsCxt preds <*> dsType ty
 dsType (AppT t1 t2) = DAppT <$> dsType t1 <*> dsType t2
 dsType (SigT ty ki) = DSigT <$> dsType ty <*> dsType ki
 dsType (VarT name) = return $ DVarT name
@@ -1180,6 +1186,9 @@ dsType (AppKindT t k) = DAppKindT <$> dsType t <*> dsType k
 dsType (ImplicitParamT n t) = do
   t' <- dsType t
   return $ DConT ''IP `DAppT` DLitT (StrTyLit n) `DAppT` t'
+#endif
+#if __GLASGOW_HASKELL__ >= 809
+dsType (ForallVisT tvbs ty) = DForallT ForallVis <$> mapM dsTvb tvbs <*> dsType ty
 #endif
 
 -- | Desugar a @TyVarBndr@
@@ -1245,12 +1254,7 @@ dsPred (EqualP t1 t2) = do
 dsPred t
   | Just ts <- splitTuple_maybe t
   = concatMapM dsPred ts
-dsPred (ForallT tvbs cxt p) = do
-  ps' <- dsPred p
-  case ps' of
-    [p'] -> (:[]) <$> (DForallT <$> mapM dsTvb tvbs <*> dsCxt cxt <*> pure p')
-    _    -> fail "Cannot desugar constraint tuples in the body of a quantified constraint"
-              -- See Trac #15334.
+dsPred (ForallT tvbs cxt p) = dsForallPred tvbs cxt p
 dsPred (AppT t1 t2) = do
   [p1] <- dsPred t1   -- tuples can't be applied!
   (:[]) <$> DAppT p1 <$> dsType t2
@@ -1298,12 +1302,33 @@ dsPred (ImplicitParamT n t) = do
   t' <- dsType t
   return [DConT ''IP `DAppT` DLitT (StrTyLit n) `DAppT` t']
 #endif
+#if __GLASGOW_HASKELL__ >= 809
+dsPred (ForallVisT tvbs p) = dsForallPred tvbs [] p
+#endif
+
+-- | Desugar a quantified constraint.
+dsForallPred :: DsMonad q => [TyVarBndr] -> Cxt -> Pred -> q DCxt
+dsForallPred tvbs cxt p = do
+  ps' <- dsPred p
+  case ps' of
+    [p'] -> (:[]) <$> (mkDForallConstrainedT ForallInvis
+                         <$> mapM dsTvb tvbs <*> dsCxt cxt <*> pure p')
+    _    -> fail "Cannot desugar constraint tuples in the body of a quantified constraint"
+              -- See Trac #15334.
 #endif
 
 -- | Like 'reify', but safer and desugared. Uses local declarations where
 -- available.
 dsReify :: DsMonad q => Name -> q (Maybe DInfo)
 dsReify = traverse dsInfo <=< reifyWithLocals_maybe
+
+-- Given a list of `forall`ed type variable binders and a context, construct
+-- a DType using DForallT and DConstrainedT as appropriate. The phrase
+-- "as appropriate" is used because DConstrainedT will not be used if the
+-- context is empty, per Note [Desugaring and sweetening ForallT].
+mkDForallConstrainedT :: ForallVisFlag -> [DTyVarBndr] -> DCxt -> DType -> DType
+mkDForallConstrainedT fvf tvbs ctxt ty =
+  DForallT fvf tvbs $ if null ctxt then ty else DConstrainedT ctxt ty
 
 -- create a list of expressions in the same order as the fields in the first argument
 -- but with the values as given in the second argument
@@ -1478,8 +1503,8 @@ toposortTyVarsOf tys =
       varKindSigs = foldMap go_ty tys
         where
           go_ty :: DType -> Map Name DKind
-          go_ty (DForallT tvbs ctxt t) =
-            go_tvbs tvbs (foldMap go_ty ctxt `mappend` go_ty t)
+          go_ty (DForallT _ tvbs t) = go_tvbs tvbs (go_ty t)
+          go_ty (DConstrainedT ctxt t) = foldMap go_ty ctxt `mappend` go_ty t
           go_ty (DAppT t1 t2) = go_ty t1 `mappend` go_ty t2
           go_ty (DAppKindT t k) = go_ty t `mappend` go_ty k
           go_ty (DSigT t k) =
@@ -1575,16 +1600,67 @@ dtvbName :: DTyVarBndr -> Name
 dtvbName (DPlainTV n)    = n
 dtvbName (DKindedTV n _) = n
 
--- | Decompose a function type into its type variables, its context, its
--- argument types, and its result type.
-unravel :: DType -> ([DTyVarBndr], [DPred], [DType], DType)
-unravel (DForallT tvbs cxt ty) =
-  let (tvbs', cxt', tys, res) = unravel ty in
-  (tvbs ++ tvbs', cxt ++ cxt', tys, res)
-unravel (DAppT (DAppT DArrowT t1) t2) =
-  let (tvbs, cxt, tys, res) = unravel t2 in
-  (tvbs, cxt, t1 : tys, res)
-unravel t = ([], [], [], t)
+-- | Reconstruct an arrow 'DType' from its argument and result types.
+ravelDType :: DFunArgs -> DType -> DType
+ravelDType DFANil                     res = res
+ravelDType (DFAForalls fvf tvbs args) res = DForallT fvf tvbs (ravelDType args res)
+ravelDType (DFACxt cxt args)          res = DConstrainedT cxt (ravelDType args res)
+ravelDType (DFAAnon t args)           res = DAppT (DAppT DArrowT t) (ravelDType args res)
+
+-- | Decompose a function 'DType' into its arguments (the 'DFunArgs') and its
+-- result type (the 'DType).
+unravelDType :: DType -> (DFunArgs, DType)
+unravelDType (DForallT fvf tvbs ty) =
+  let (args, res) = unravelDType ty in
+  (DFAForalls fvf tvbs args, res)
+unravelDType (DConstrainedT cxt ty) =
+  let (args, res) = unravelDType ty in
+  (DFACxt cxt args, res)
+unravelDType (DAppT (DAppT DArrowT t1) t2) =
+  let (args, res) = unravelDType t2 in
+  (DFAAnon t1 args, res)
+unravelDType t = (DFANil, t)
+
+-- | The list of arguments in a function 'DType'.
+data DFunArgs
+  = DFANil
+    -- ^ No more arguments.
+  | DFAForalls ForallVisFlag [DTyVarBndr] DFunArgs
+    -- ^ A series of @forall@ed type variables followed by a dot (if
+    --   'ForallInvis') or an arrow (if 'ForallVis'). For example,
+    --   the type variables @a1 ... an@ in @forall a1 ... an. r@.
+  | DFACxt DCxt DFunArgs
+    -- ^ A series of constraint arguments followed by @=>@. For example,
+    --   the @(c1, ..., cn)@ in @(c1, ..., cn) => r@.
+  | DFAAnon DType DFunArgs
+    -- ^ An anonymous argument followed by an arrow. For example, the @a@
+    --   in @a -> r@.
+  deriving (Eq, Show, Typeable, Data, Generic)
+
+-- | A /visible/ function argument type (i.e., one that must be supplied
+-- explicitly in the source code). This is in contrast to /invisible/
+-- arguments (e.g., the @c@ in @c => r@), which are instantiated without
+-- the need for explicit user input.
+data DVisFunArg
+  = DVisFADep DTyVarBndr
+    -- ^ A visible @forall@ (e.g., @forall a -> a@).
+  | DVisFAAnon DType
+    -- ^ An anonymous argument followed by an arrow (e.g., @a -> r@).
+  deriving (Eq, Show, Typeable, Data, Generic)
+
+-- | Filter the visible function arguments from a list of 'DFunArgs'.
+filterDVisFunArgs :: DFunArgs -> [DVisFunArg]
+filterDVisFunArgs DFANil = []
+filterDVisFunArgs (DFAForalls fvf tvbs args) =
+  case fvf of
+    ForallVis   -> map DVisFADep tvbs ++ args'
+    ForallInvis -> args'
+  where
+    args' = filterDVisFunArgs args
+filterDVisFunArgs (DFACxt _ args) =
+  filterDVisFunArgs args
+filterDVisFunArgs (DFAAnon t args) =
+  DVisFAAnon t:filterDVisFunArgs args
 
 -- | Decompose an applied type into its individual components. For example, this:
 --
@@ -1620,3 +1696,56 @@ extractTvbKind (DKindedTV _ k) = Just k
 -- version of 'undefined'.)
 unusedArgument :: a
 unusedArgument = error "Unused"
+
+{-
+Note [Desugaring and sweetening ForallT]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ForallT constructor from template-haskell is tremendously awkward. Because
+ForallT contains both a list of type variable binders and constraint arguments,
+ForallT expressions can be ambiguous when one of these lists is empty. For
+example, consider this expression with no constraints:
+
+  ForallT [PlainTV a] [] (VarT a)
+
+What should this desugar to in th-desugar, which must maintain a clear
+separation between type variable binders and constraints? There are two
+possibilities:
+
+1. DForallT DForallInvis [DPlainTV a] (DVarT a)
+   (i.e., forall a. a)
+2. DForallT DForallInvis [DPlainTV a] (DConstrainedT [] (DVarT a))
+   (i.e., forall a. () => a)
+
+Template Haskell generally drops these empty lists when splicing Template
+Haskell expressions, so we would like to do the same in th-desugar to mimic
+TH's behavior as closely as possible. However, there are some situations where
+dropping empty lists of `forall`ed type variable binders can change the
+semantics of a program. For instance, contrast `foo :: forall. a -> a` (which
+is an error) with `foo :: a -> a` (which is fine). Therefore, we try to
+preserve empty `forall`s to the best of our ability.
+
+Here is an informal specification of how th-desugar should handle different sorts
+of ambiguity. First, a specification for desugaring.
+Let `tvbs` and `ctxt` be non-empty:
+
+* `ForallT tvbs [] ty` should desugar to `DForallT DForallInvis tvbs ty`.
+* `ForallT [] ctxt ty` should desguar to `DForallT DForallInvis [] (DConstrainedT ctxt ty)`.
+* `ForallT [] [] ty`   should desugar to `DForallT DForallInvis [] ty`.
+* For all other cases, just straightforwardly desugar
+  `ForallT tvbs ctxt ty` to `DForallT DForallInvis tvbs (DConstraintedT ctxt ty)`.
+
+For sweetening:
+
+* `DForallT DForallInvis tvbs (DConstrainedT ctxt ty)` should sweeten to `ForallT tvbs ctxt ty`.
+* `DForallT DForallInvis []   (DConstrainedT ctxt ty)` should sweeten to `ForallT [] ctxt ty`.
+* `DForallT DForallInvis tvbs (DConstrainedT [] ty)`   should sweeten to `ForallT tvbs [] ty`.
+* `DForallT DForallInvis []   (DConstrainedT [] ty)`   should sweeten to `ForallT [] [] ty`.
+* For all other cases, just straightforwardly sweeten
+  `DForallT DForallInvis tvbs ty` to `ForallT tvbs [] ty` and
+  `DConstrainedT ctxt ty` to `ForallT [] ctxt ty`.
+
+One gotcha of this specification is the th-desugar roundtripping will turn the
+type `() => a` into `forall a. () => a`. In practice, Template Haskell won't
+let you do anything bad with this due to the sorts of issues documented in
+GHC #16396.
+-}

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -27,7 +27,8 @@ fvDType :: DType -> OSet Name
 fvDType = go
   where
     go :: DType -> OSet Name
-    go (DForallT tvbs ctxt ty) = fv_dtvbs tvbs (foldMap fvDType ctxt <> go ty)
+    go (DForallT _ tvbs ty)    = fv_dtvbs tvbs (go ty)
+    go (DConstrainedT ctxt ty) = foldMap fvDType ctxt <> go ty
     go (DAppT t1 t2)           = go t1 <> go t2
     go (DAppKindT t k)         = go t <> go k
     go (DSigT ty ki)           = go ty <> go ki

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -23,7 +23,7 @@ import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Instances ()
 import Language.Haskell.TH.Lift
 
-$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DTyVarBndr
+$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''ForallVisFlag, ''DTyVarBndr
                  , ''DMatch, ''DClause, ''DLetDec, ''DDec, ''DDerivClause, ''DCon
                  , ''DConFields, ''DForeign, ''DPragma, ''DRuleBndr, ''DTySynEqn
                  , ''DPatSynDir , ''NewOrData, ''DDerivStrategy
@@ -36,5 +36,7 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DTyVarBndr
                  , ''PatSynArgs
 #endif
 
-                 , ''TypeArg, ''DTypeArg
+                 , ''TypeArg,   ''DTypeArg
+                 , ''FunArgs,   ''DFunArgs
+                 , ''VisFunArg, ''DVisFunArg
                  ])

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -108,9 +108,14 @@ getDataD err name = do
   where
     go tvbs mk cons = do
       k <- maybe (pure (ConT typeKindName)) (runQ . resolveTypeSynonyms) mk
-      extra_tvbs <- mkExtraKindBindersGeneric unravelType KindedTV k
+      extra_tvbs <- mkExtraKindBindersGeneric unravelType filterVisFunArgs
+                                              KindedTV elim_vfa k
       let all_tvbs = tvbs ++ extra_tvbs
       return (all_tvbs, cons)
+
+    elim_vfa :: (TyVarBndr -> r) -> (Kind -> r) -> VisFunArg -> r
+    elim_vfa dep _    (VisFADep tvb) = dep tvb
+    elim_vfa _   anon (VisFAAnon k)  = anon k
 
     badDeclaration =
           fail $ "The name (" ++ (show name) ++ ") refers to something " ++

--- a/Language/Haskell/TH/Desugar/Subst.hs
+++ b/Language/Haskell/TH/Desugar/Subst.hs
@@ -40,11 +40,12 @@ type DSubst = M.Map Name DType
 
 -- | Capture-avoiding substitution on types
 substTy :: Quasi q => DSubst -> DType -> q DType
-substTy vars (DForallT tvbs cxt ty) =
+substTy vars (DForallT fvf tvbs ty) =
   substTyVarBndrs vars tvbs $ \vars' tvbs' -> do
-    cxt' <- mapM (substTy vars') cxt
     ty' <- substTy vars' ty
-    return $ DForallT tvbs' cxt' ty'
+    return $ DForallT fvf tvbs' ty'
+substTy vars (DConstrainedT cxt ty) =
+  DConstrainedT <$> mapM (substTy vars) cxt <*> substTy vars ty
 substTy vars (DAppT t1 t2) =
   DAppT <$> substTy vars t1 <*> substTy vars t2
 substTy vars (DAppKindT t k) =

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -525,12 +525,7 @@ predToTH (DForallT ForallInvis tvbs (DConstrainedT ctxt p)) =
 predToTH (DForallT fvf tvbs p) =
   case fvf of
     ForallInvis -> ForallT tvbs' [] p'
-    ForallVis ->
-#if __GLASGOW_HASKELL__ >= 809
-      ForallVisT tvbs' p'
-#else
-      error "Visible dependent quantification supported only in GHC 8.10+"
-#endif
+    ForallVis   -> error "Visible dependent quantifier spotted at head of a constraint"
   where
     tvbs' = map tvbToTH tvbs
     p'    = predToTH p

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -53,7 +53,6 @@ import Data.Traversable
 import Data.Maybe
 
 #if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
 import Data.Monoid
 #endif
 

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -30,8 +30,7 @@ module Language.Haskell.TH.Desugar.Util (
   unboxedTupleNameDegree_maybe, splitTuple_maybe,
   topEverywhereM, isInfixDataCon,
   isTypeKindName, typeKindName,
-  mkExtraKindBindersGeneric, unSigType, unfoldType,
-  ForallVisFlag(..), FunArgs(..), VisFunArg(..),
+  unSigType, unfoldType, ForallVisFlag(..), FunArgs(..), VisFunArg(..),
   filterVisFunArgs, ravelType, unravelType,
   TypeArg(..), applyType, filterTANormals, unSigTypeArg, probablyWrongUnTypeArg
 #if __GLASGOW_HASKELL__ >= 800
@@ -207,25 +206,6 @@ splitTuple_maybe t = go [] t
           | length args == degree
           = Just args
         go _ _ = Nothing
-
--- | Like 'mkExtraDKindBinders', but parameterized to allow working over both
--- 'Kind'/'FunArgs'/'VisFunArg'/'TyVarBndr' and
--- 'DKind'/'DFunArgs'/'DVisFunArg'/'DTyVarBndr'.
-mkExtraKindBindersGeneric
-  :: forall q kind funArgs visFunArg tyVarBndr. Quasi q
-  => (kind -> (funArgs, kind))
-  -> (funArgs -> [visFunArg])
-  -> (Name -> kind -> tyVarBndr)
-  -> (forall r. (tyVarBndr -> r) -> (kind -> r) -> visFunArg -> r)
-  -> kind -> q [tyVarBndr]
-mkExtraKindBindersGeneric unravel filter_vis_fun_args
-                          mk_kinded_tv elim_vfa k = do
-  let (fun_args, _) = unravel k
-      vis_fun_args  = filter_vis_fun_args fun_args
-  mapM mk_tvb vis_fun_args
-  where
-    mk_tvb :: visFunArg -> q tyVarBndr
-    mk_tvb = elim_vfa return (\ki -> mk_kinded_tv <$> qNewName "a" <*> return ki)
 
 -- | Is a @forall@ invisible (e.g., @forall a b. {...}@, with a dot) or visible
 -- (e.g., @forall a b -> {...}@, with an arrow)?

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -30,7 +30,9 @@ module Language.Haskell.TH.Desugar.Util (
   unboxedTupleNameDegree_maybe, splitTuple_maybe,
   topEverywhereM, isInfixDataCon,
   isTypeKindName, typeKindName,
-  mkExtraKindBindersGeneric, unravelType, unSigType, unfoldType,
+  mkExtraKindBindersGeneric, unSigType, unfoldType,
+  ForallVisFlag(..), FunArgs(..), VisFunArg(..),
+  filterVisFunArgs, ravelType, unravelType,
   TypeArg(..), applyType, filterTANormals, unSigTypeArg, probablyWrongUnTypeArg
 #if __GLASGOW_HASKELL__ >= 800
   , bindIP
@@ -45,7 +47,6 @@ import qualified Language.Haskell.TH.Desugar.OSet as OS
 import Language.Haskell.TH.Desugar.OSet (OSet)
 import Language.Haskell.TH.Syntax
 
-import Control.Monad ( replicateM )
 import qualified Control.Monad.Fail as Fail
 import Data.Foldable
 import Data.Generics hiding ( Fixity )
@@ -53,6 +54,7 @@ import Data.Traversable
 import Data.Maybe
 
 #if __GLASGOW_HASKELL__ < 710
+import Control.Applicative
 import Data.Monoid
 #endif
 
@@ -207,27 +209,105 @@ splitTuple_maybe t = go [] t
         go _ _ = Nothing
 
 -- | Like 'mkExtraDKindBinders', but parameterized to allow working over both
--- 'Kind'/'TyVarBndr' and 'DKind'/'DTyVarBndr'.
+-- 'Kind'/'FunArgs'/'VisFunArg'/'TyVarBndr' and
+-- 'DKind'/'DFunArgs'/'DVisFunArg'/'DTyVarBndr'.
 mkExtraKindBindersGeneric
-  :: Quasi q
-  => (kind -> ([tyVarBndr], [pred], [kind], kind))
+  :: forall q kind funArgs visFunArg tyVarBndr. Quasi q
+  => (kind -> (funArgs, kind))
+  -> (funArgs -> [visFunArg])
   -> (Name -> kind -> tyVarBndr)
+  -> (forall r. (tyVarBndr -> r) -> (kind -> r) -> visFunArg -> r)
   -> kind -> q [tyVarBndr]
-mkExtraKindBindersGeneric unravel mkKindedTV k = do
-  let (_, _, args, _) = unravel k
-  names <- replicateM (length args) (qNewName "a")
-  return (zipWith mkKindedTV names args)
+mkExtraKindBindersGeneric unravel filter_vis_fun_args
+                          mk_kinded_tv elim_vfa k = do
+  let (fun_args, _) = unravel k
+      vis_fun_args  = filter_vis_fun_args fun_args
+  mapM mk_tvb vis_fun_args
+  where
+    mk_tvb :: visFunArg -> q tyVarBndr
+    mk_tvb = elim_vfa return (\ki -> mk_kinded_tv <$> qNewName "a" <*> return ki)
 
--- | Decompose a function 'Type' into its type variables, its context, its
--- argument types, and its result type.
-unravelType :: Type -> ([TyVarBndr], [Pred], [Type], Type)
+-- | Is a @forall@ invisible (e.g., @forall a b. {...}@, with a dot) or visible
+-- (e.g., @forall a b -> {...}@, with an arrow)?
+data ForallVisFlag
+  = ForallVis   -- ^ A visible @forall@ (with an arrow)
+  | ForallInvis -- ^ An invisible @forall@ (with a dot)
+  deriving (Eq, Show, Typeable, Data)
+
+-- | The list of arguments in a function 'Type'.
+data FunArgs
+  = FANil
+    -- ^ No more arguments.
+  | FAForalls ForallVisFlag [TyVarBndr] FunArgs
+    -- ^ A series of @forall@ed type variables followed by a dot (if
+    --   'ForallInvis') or an arrow (if 'ForallVis'). For example,
+    --   the type variables @a1 ... an@ in @forall a1 ... an. r@.
+  | FACxt Cxt FunArgs
+    -- ^ A series of constraint arguments followed by @=>@. For example,
+    --   the @(c1, ..., cn)@ in @(c1, ..., cn) => r@.
+  | FAAnon Type FunArgs
+    -- ^ An anonymous argument followed by an arrow. For example, the @a@
+    --   in @a -> r@.
+  deriving (Eq, Show, Typeable, Data)
+
+-- | A /visible/ function argument type (i.e., one that must be supplied
+-- explicitly in the source code). This is in contrast to /invisible/
+-- arguments (e.g., the @c@ in @c => r@), which are instantiated without
+-- the need for explicit user input.
+data VisFunArg
+  = VisFADep TyVarBndr
+    -- ^ A visible @forall@ (e.g., @forall a -> a@).
+  | VisFAAnon Type
+    -- ^ An anonymous argument followed by an arrow (e.g., @a -> r@).
+  deriving (Eq, Show, Typeable, Data)
+
+-- | Filter the visible function arguments from a list of 'FunArgs'.
+filterVisFunArgs :: FunArgs -> [VisFunArg]
+filterVisFunArgs FANil = []
+filterVisFunArgs (FAForalls fvf tvbs args) =
+  case fvf of
+    ForallVis   -> map VisFADep tvbs ++ args'
+    ForallInvis -> args'
+  where
+    args' = filterVisFunArgs args
+filterVisFunArgs (FACxt _ args) =
+  filterVisFunArgs args
+filterVisFunArgs (FAAnon t args) =
+  VisFAAnon t:filterVisFunArgs args
+
+-- | Reconstruct an arrow 'Type' from its argument and result types.
+ravelType :: FunArgs -> Type -> Type
+ravelType FANil res = res
+-- We need a special case for FAForalls ForallInvis followed by FACxt so that we may
+-- collapse them into a single ForallT when raveling.
+-- See Note [Desugaring and sweetening ForallT] in L.H.T.Desugar.Core.
+ravelType (FAForalls ForallInvis tvbs (FACxt p args)) res =
+  ForallT tvbs p (ravelType args res)
+ravelType (FAForalls ForallInvis  tvbs  args)  res = ForallT tvbs [] (ravelType args res)
+ravelType (FAForalls ForallVis   _tvbs _args) _res =
+#if __GLASGOW_HASKELL__ >= 809
+      ForallVisT _tvbs (ravelType _args _res)
+#else
+      error "Visible dependent quantification supported only on GHC 8.10+"
+#endif
+ravelType (FACxt cxt args) res = ForallT [] cxt (ravelType args res)
+ravelType (FAAnon t args)  res = AppT (AppT ArrowT t) (ravelType args res)
+
+-- | Decompose a function 'Type' into its arguments (the 'FunArgs') and its
+-- result type (the 'Type).
+unravelType :: Type -> (FunArgs, Type)
 unravelType (ForallT tvbs cxt ty) =
-  let (tvbs', cxt', tys, res) = unravelType ty in
-  (tvbs ++ tvbs', cxt ++ cxt', tys, res)
+  let (args, res) = unravelType ty in
+  (FAForalls ForallInvis tvbs (FACxt cxt args), res)
 unravelType (AppT (AppT ArrowT t1) t2) =
-  let (tvbs, cxt, tys, res) = unravelType t2 in
-  (tvbs, cxt, t1 : tys, res)
-unravelType t = ([], [], [], t)
+  let (args, res) = unravelType t2 in
+  (FAAnon t1 args, res)
+#if __GLASGOW_HASKELL__ >= 809
+unravelType (ForallVisT tvbs ty) =
+  let (args, res) = unravelType ty in
+  (FAForalls ForallVis tvbs args, res)
+#endif
+unravelType t = (FANil, t)
 
 -- | Remove all of the explicit kind signatures from a 'Type'.
 unSigType :: Type -> Type

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -52,6 +52,10 @@ $(S.dectest16)
 $(S.dectest17)
 #endif
 
+#if __GLASGOW_HASKELL__ >= 809
+$(S.dectest18)
+#endif
+
 $(fmap unqualify S.instance_test)
 
 $(fmap unqualify S.imp_inst_test1)

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -77,6 +77,10 @@ $(return $ decsToTH [S.ds_dectest16])
 $(return $ decsToTH [S.ds_dectest17])
 #endif
 
+#if __GLASGOW_HASKELL__ >= 809
+$(dsDecSplice S.dectest18)
+#endif
+
 $(do decs <- S.rec_sel_test
      withLocalDeclarations decs $ do
        [DDataD nd [] name [DPlainTV tvbName] k cons []] <- dsDecs decs

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -428,6 +428,11 @@ dectest17 = return [ StandaloneDerivD
                                      (ConT ''ExData2 `AppT` VarT (mkName "a")))) ]
 #endif
 
+#if __GLASGOW_HASKELL__ >= 809
+dectest18 = [d| data Dec18 :: forall k -> k -> * where
+                  MkDec18 :: forall k (a :: k). Dec18 k a |]
+#endif
+
 instance_test = [d| instance (Show a, Show b) => Show (a -> b) where
                        show _ = "function" |]
 
@@ -594,6 +599,10 @@ reifyDecs = [d|
 
   class R30 a where
     r31 :: a -> b -> a
+
+#if __GLASGOW_HASKELL__ >= 809
+  type family R32 :: forall k -> k -> * where
+#endif
   |]
 
 reifyDecsNames :: [Name]
@@ -610,6 +619,9 @@ reifyDecsNames = map mkName
   , "R25", "r26", "R28", "r29"
 #endif
   , "R30", "r31"
+#if __GLASGOW_HASKELL__ >= 809
+  , "R32"
+#endif
   ]
 
 simplCaseTests :: [Q Exp]

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -1,5 +1,5 @@
 name:           th-desugar
-version:        1.10
+version:        1.11
 cabal-version:  >= 1.10
 synopsis:       Functions to desugar Template Haskell
 homepage:       https://github.com/goldfirere/th-desugar


### PR DESCRIPTION
This adds support for visible dependent quantification (new in GHC 8.10). There are two main changes involved in this:

* The existing `DForallT` constructor is now split into two constructors, `DForallT` (for type variable binders) and `DConstrainedT` (for constraints).

  The process of desugaring and sweetening these constructors is somewhat tricky. See `Note [Desugaring and sweetening ForallT]` in `L.H.T.Desugar.Core` for the full story.
* The `unravel` function now chunks up function arguments using an auxiliary `DFunArgs` data type. We also need a version of this for `Type`s, so there is now both `unravelType` and `unravelDType` (the existing `unravel` function was renamed to `unravelDType`).

See the `CHANGES.md` file for the full list of changes.

Fixes #113.