### PR TITLE
Fix #100 by making maybeReifyCon/findRecSelector GADT-aware

### DIFF
--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -24,7 +24,7 @@ module Language.Haskell.TH.Desugar.Util (
   thirdOf3, splitAtList, extractBoundNamesDec,
   extractBoundNamesPat,
   tvbToType, tvbToTypeWithSig, tvbToTANormalWithSig,
-  nameMatches, thdOf3, firstMatch,
+  nameMatches, thdOf3, liftFst, liftSnd, firstMatch,
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   tupleDegree_maybe, tupleNameDegree_maybe, unboxedTupleDegree_maybe,
   unboxedTupleNameDegree_maybe, splitTuple_maybe,
@@ -32,7 +32,7 @@ module Language.Haskell.TH.Desugar.Util (
   isTypeKindName, typeKindName,
   unSigType, unfoldType, ForallVisFlag(..), FunArgs(..), VisFunArg(..),
   filterVisFunArgs, ravelType, unravelType,
-  TypeArg(..), applyType, filterTANormals, unSigTypeArg, probablyWrongUnTypeArg
+  TypeArg(..), applyType, filterTANormals, probablyWrongUnTypeArg
 #if __GLASGOW_HASKELL__ >= 800
   , bindIP
 #endif
@@ -373,11 +373,6 @@ filterTANormals = mapMaybe getTANormal
     getTANormal (TANormal t) = Just t
     getTANormal (TyArg {})   = Nothing
 
--- | Remove all of the explicit kind signatures from a 'TypeArg'.
-unSigTypeArg :: TypeArg -> TypeArg
-unSigTypeArg (TANormal t) = TANormal (unSigType t)
-unSigTypeArg (TyArg k)    = TyArg (unSigType k)
-
 -- | Extract the underlying 'Type' or 'Kind' from a 'TypeArg'. This forgets
 -- information about whether a type is a normal argument or not, so use with
 -- caution.
@@ -465,6 +460,12 @@ splitAtList (_ : _) [] = ([], [])
 
 thdOf3 :: (a,b,c) -> c
 thdOf3 (_,_,c) = c
+
+liftFst :: (a -> b) -> (a, c) -> (b, c)
+liftFst f (a,c) = (f a, c)
+
+liftSnd :: (a -> b) -> (c, a) -> (c, b)
+liftSnd f (c,a) = (c, f a)
 
 thirdOf3 :: (a -> b) -> (c, d, a) -> (c, d, b)
 thirdOf3 f (c, d, a) = (c, d, f a)

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -611,6 +611,9 @@ reifyDecs = [d|
   type R32 :: forall k -> k -> *
   type family R32 :: forall k -> k -> * where
 #endif
+
+  data R33 a where
+    R34 :: { r35 :: Int } -> R33 Int
   |]
 
 reifyDecsNames :: [Name]
@@ -630,6 +633,7 @@ reifyDecsNames = map mkName
 #if __GLASGOW_HASKELL__ >= 809
   , "R32"
 #endif
+  , "R33", "R34", "r35"
   ]
 
 simplCaseTests :: [Q Exp]


### PR DESCRIPTION
Deep in the swamps of `L.H.TH.Desugar.Reify` is the `maybeReifyCon` function, which locally reifies the type of a data constructor. This code was deeply buggy in the presence of GADT constructors, as `maybeReifyCon` would copy information from the data type head instead of the data type in the constructor's result type. This led to a variety of bugs observed in #100.

This fixes the issue by giving `maybeReifyCon` a slightly different code path for GADT constructors. See the internal `con_to_type` function for the full story.

A similar fix was also applied to `findRecSelector`, which locally reifies the type of a record selector. This also needs slightly different logic for GADTs, so I crafted a custom `RecSelInfo` data type for this purpose to encode the extra information that GADTs provide (in the form of their return types).

Fixes #100.