### PR TITLE
Use NoMonomorphismRestriction in Test.Splices

### DIFF
--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -10,7 +10,7 @@ rae@cs.brynmawr.edu
              DataKinds, PolyKinds, GADTs, MultiParamTypeClasses,
              FunctionalDependencies, FlexibleInstances, StandaloneDeriving,
              DefaultSignatures, ConstraintKinds, GADTs, ViewPatterns,
-             TupleSections #-}
+             TupleSections, NoMonomorphismRestriction #-}
 
 #if __GLASGOW_HASKELL__ >= 711
 {-# LANGUAGE TypeApplications #-}


### PR DESCRIPTION
Attempting to compile `th-desugar`'s test suite on GHC HEAD yields many errors with this general shape:

```
[1 of 6] Compiling Splices          ( Test/Splices.hs, /tmp/ghc12027_0/ghc_24.o )

Test/Splices.hs:118:16: error:
    • Ambiguous type variable ‘m35’ arising from a quotation bracket
      prevents the constraint ‘(Quote m35)’ from being solved.
      Relevant bindings include
        test4_tuples :: m35 Exp (bound at Test/Splices.hs:118:1)
      Probable fix: use a type annotation to specify what ‘m35’ should be.
      These potential instance exist:
        instance Quote Q -- Defined in ‘Language.Haskell.TH.Syntax’
    • In the expression:
        [| (\ (a, _) (# b, _ #) -> a + b) (1, 2) (# 3, 4 #) |]
      In an equation for ‘test4_tuples’:
          test4_tuples
            = [| (\ (a, _) (# b, _ #) -> a + b) (1, 2) (# 3, 4 #) |]
    |
118 | test4_tuples = [| (\(a, _) (# b, _ #) -> a + b) (1,2) (# 3, 4 #) |]
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is due to the [Overloaded Quotation Brackets](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0246-overloaded-bracket.rst) proposal having been implemented. There are two ways we could fix this:

1. Give `test4_tuples` _et al._ explicit type signatures.
2. Use `NoMonomorphismRestriction` to avoid this behavior in the first place.

Option (2) is much less work, so I went with that.