### PR TITLE
Fix #132

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@ Version 1.11 [????.??.??]
   `DDec`.
 * Add `dsReifyType`, `reifyTypeWithLocals_maybe`, and `reifyTypeWithLocals`,
   which allow looking up the types or kinds of locally declared entities.
+* Fix a bug in which `reifyFixityWithLocals` would not look into local fixity
+  declarations inside of type classes.
 
 Version 1.10
 ------------

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -244,8 +244,10 @@ reifyInDecs n decs = snd `fmap` firstMatch (reifyInDec n decs) decs
 reifyFixityInDecs :: Name -> [Dec] -> Maybe Fixity
 reifyFixityInDecs n = firstMatch match_fixity
   where
-    match_fixity (InfixD fixity n') | n `nameMatches` n' = Just fixity
-    match_fixity _                                       = Nothing
+    match_fixity (InfixD fixity n')        | n `nameMatches` n'
+                                           = Just fixity
+    match_fixity (ClassD _ _ _ _ sub_decs) = firstMatch match_fixity sub_decs
+    match_fixity _                         = Nothing
 
 -- | A reified thing along with the name of that thing.
 type Named a = (Name, a)


### PR DESCRIPTION
Add a missing case for `ClassD` in `reifyFixityWithLocals`.