### PR TITLE
Locally reify classes with type family defaults correctly (#134)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@ Version 1.11 [????.??.??]
   which allow looking up the types or kinds of locally declared entities.
 * Fix a bug in which `reifyFixityWithLocals` would not look into local fixity
   declarations inside of type classes.
+* Fix a bug in which `reifyFixityWithLocals` would return incorrect results
+  for classes with associated type family defaults.
 
 Version 1.10
 ------------

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -315,7 +315,10 @@ reifyInDec n decs (ClassD _ ty_name tvbs _ sub_decs)
                                 reifyFixityInDecs n $ sub_decs ++ decs))
 #endif
 reifyInDec n decs (ClassD _ _ _ _ sub_decs)
-  | Just info <- firstMatch (reifyInDec n (sub_decs ++ decs)) sub_decs
+  | Just info <- firstMatch (reifyInDec n decs) sub_decs
+                 -- Important: don't pass (sub_decs ++ decs) to reifyInDec
+                 -- above, or else type family defaults can be confused for
+                 -- actual instances. See #134.
   = Just info
 #if __GLASGOW_HASKELL__ >= 711
 reifyInDec n decs (InstanceD _ _ _ sub_decs)
@@ -599,6 +602,7 @@ quantifyClassDecMethods (ClassD cxt cls_name cls_tvbs fds sub_decs)
     go (SigD n ty) =
       Just $ SigD n
            $ quantifyClassMethodType cls_name cls_tvbs prepend_cls ty
+    go d@(TySynInstD {})      = Just d
 #if __GLASGOW_HASKELL__ > 710
     go d@(OpenTypeFamilyD {}) = Just d
     go d@(DataFamilyD {})     = Just d

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -516,6 +516,11 @@ reifyDecs = [d|
   class R2 a b where
     r3 :: a -> b -> c -> a
     type R4 b a :: *
+#if __GLASGOW_HASKELL__ >= 800
+    -- Only define this on GHC 8.0 or later, since TH had trouble quoting
+    -- associated type family defaults before then.
+    type R4 b a = Either a b
+#endif
     data R5 a :: *
 
   data R6 a = R7 { r8 :: a -> a, r9 :: Bool }


### PR DESCRIPTION
There were two separate bugs in `L.H.T.D.Reify`, one in `reifyInDec` and one in `quantifyClassDecMethods`, that caused local reification to return incorrect results for type classes that contain associated type family defaults. Fortunately, both bugs are extremely simple to fix.

Fixes #134.