### PR TITLE
Remove conExistentialTvbs, simplify spec of getRecordSelectors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 `th-desugar` release notes
 ==========================
 
-next [????.??.??]
------------------
+Version 1.12 [????.??.??]
+-------------------------
 * Make the test suite compile with GHC 8.12.
 
 Version 1.11 [2020.03.25]

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -84,8 +84,7 @@ $(dsDecSplice S.dectest18)
 $(do decs <- S.rec_sel_test
      withLocalDeclarations decs $ do
        [DDataD nd [] name [DPlainTV tvbName] k cons []] <- dsDecs decs
-       let arg_ty = (DConT name) `DAppT` (DVarT tvbName)
-       recsels <- getRecordSelectors arg_ty cons
+       recsels <- getRecordSelectors cons
        let num_sels = length recsels `div` 2 -- ignore type sigs
        when (num_sels /= S.rec_sel_test_num_sels) $
          qReport True $ "Wrong number of record selectors extracted.\n"

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -474,13 +474,13 @@ type instance Poly x = Int
 flatten_dvald_test = [| let (a,b,c) = ("foo", 4, False) in
                         show a ++ show b ++ show c |]
 
-rec_sel_test = [d| data RecordSel a = forall b. (Show a, Eq b) =>
+rec_sel_test = [d| data RecordSel a = Show a =>
                                       MkRecord { recsel1 :: (Int, a)
-                                            , recsel_naughty :: (a, b)
-                                            , recsel2 :: (forall b. b -> a)
-                                            , recsel3 :: Bool }
-                                    | MkRecord2 { recsel4 :: (a, a) } |]
-rec_sel_test_num_sels = 4 :: Int   -- exclude naughty one
+                                               , recsel2 :: (forall b. b -> a)
+                                               , recsel3 :: Bool }
+                                    | MkRecord2 { recsel3 :: Bool
+                                                , recsel4 :: (a, a) } |]
+rec_sel_test_num_sels = 4 :: Int
 
 testRecSelTypes :: Int -> Q Exp
 testRecSelTypes n = do

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -1,5 +1,5 @@
 name:           th-desugar
-version:        1.11
+version:        1.12
 cabal-version:  >= 1.10
 synopsis:       Functions to desugar Template Haskell
 homepage:       https://github.com/goldfirere/th-desugar


### PR DESCRIPTION
As observed in goldfirere/singletons#443,
the `conExistentialTvbs` function is completely broken. While it may
techincally be possible to repair `conExistentialTvbs` (see
goldfirere/singletons#443 (comment)),
it would require adopting _ad hoc_ heuristics that are difficult to
specify.

I decided to take a step back and ask: why does `conExistentialTvbs`
even exist in the first place? In the case of `th-desugar`, its only
call site is `getRecordSelectors`, which uses `conExistentialTvbs` to
filter out naughty record selectors. But this is a heavy price to pay
for the convenience of supporting this corner case. Moreover, we're
`th-desugar` is not internally consistent about supporting this
corner case. See `L.H.T.Desugar.Reify.maybeReifyCon`, which states
that it does not "ferret out" naughty record selectors.

Bottom line: let's not bother trying to compute existential type
variables, especially since they're so much trouble. This means that:

1. `getRecordSelectors` will include naughty record selectors in its
   results. This is a mite unfortunate, but I would prefer to wait
   for someone to shout about this before investing more effort into
   it.
2. Some validity checks in `singletons` which use
   `conExistentialTvbs` will now be less precise. This isn't a huge
   deal—it just means that erroneous programs which `singletons`
   used to give specialized error messages for will now just go
   through, resulting in an error message on GHC's behalf.

One knock-on change from this patch is that the first argument to
`getRecordSelectors` is no longer required, as its sole purpose was
to help compute existential type variables.