### PR TITLE
Support explicit specificity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.10
+# version: 0.10.3
 #
 version: ~> 1.0
 language: c
@@ -154,5 +154,5 @@ script:
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all
 
-# REGENDATA ("0.10",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.10.3",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -23,7 +23,7 @@ import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Instances ()
 import Language.Haskell.TH.Lift
 
-$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''ForallVisFlag, ''DTyVarBndr
+$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DForallTelescope, ''DTyVarBndr
                  , ''DMatch, ''DClause, ''DLetDec, ''DDec, ''DDerivClause, ''DCon
                  , ''DConFields, ''DForeign, ''DPragma, ''DRuleBndr, ''DTySynEqn
                  , ''DPatSynDir , ''NewOrData, ''DDerivStrategy
@@ -35,8 +35,12 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''ForallVisFlag, ''DTyVarBndr
 #if __GLASGOW_HASKELL__ < 801
                  , ''PatSynArgs
 #endif
+#if __GLASGOW_HASKELL__ < 900
+                 , ''Specificity
+#endif
 
                  , ''TypeArg,   ''DTypeArg
                  , ''FunArgs,   ''DFunArgs
                  , ''VisFunArg, ''DVisFunArg
+                 , ''ForallTelescope
                  ])

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -82,7 +82,7 @@ $(dsDecSplice S.dectest18)
 
 $(do decs <- S.rec_sel_test
      withLocalDeclarations decs $ do
-       [DDataD nd [] name [DPlainTV tvbName] k cons []] <- dsDecs decs
+       [DDataD nd [] name [DPlainTV tvbName ()] k cons []] <- dsDecs decs
        recsels <- getRecordSelectors cons
        let num_sels = length recsels `div` 2 -- ignore type sigs
        when (num_sels /= S.rec_sel_test_num_sels) $
@@ -95,5 +95,5 @@ $(do decs <- S.rec_sel_test
                  fields' = zip stricts types
              in
              DCon tvbs cxt con_name (DNormalC False fields') rty
-           plaindata = [DDataD nd [] name [DPlainTV tvbName] k (map unrecord cons) []]
+           plaindata = [DDataD nd [] name [DPlainTV tvbName ()] k (map unrecord cons) []]
        return (decsToTH plaindata ++ map letDecToTH recsels))

--- a/Test/ReifyTypeCUSKs.hs
+++ b/Test/ReifyTypeCUSKs.hs
@@ -96,7 +96,7 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
 #if __GLASGOW_HASKELL__ >= 800
            ++
            [ (8, let k = mkName "k" in
-                 DForallT ForallInvis [DPlainTV k] $
+                 DForallT (DForallInvis [DPlainTV k SpecifiedSpec]) $
                  DArrowT `DAppT` DVarT k `DAppT`
                    (DArrowT `DAppT` DVarT k `DAppT` typeKind))
            ]
@@ -105,19 +105,19 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
            ++
            [ (9, let j = mkName "j"
                      k = mkName "k" in
-                 DForallT ForallInvis [DPlainTV j] $
+                 DForallT (DForallInvis [DPlainTV j SpecifiedSpec]) $
                  DArrowT `DAppT` DVarT j `DAppT`
-                   (DForallT ForallInvis [DPlainTV k] $
+                   (DForallT (DForallInvis [DPlainTV k SpecifiedSpec]) $
                     DArrowT `DAppT` DVarT k `DAppT` typeKind))
            ]
 #endif
 #if __GLASGOW_HASKELL__ >= 809
            ++
            [ (10, let k = mkName "k" in
-                  DForallT ForallVis [DKindedTV k typeKind] $
+                  DForallT (DForallVis [DKindedTV k () typeKind]) $
                   DArrowT `DAppT` DVarT k `DAppT` typeKind)
            , (11, let k = mkName "k" in
-                  DForallT ForallVis [DPlainTV k] $
+                  DForallT (DForallVis [DPlainTV k ()]) $
                   DArrowT `DAppT` DVarT k `DAppT` typeKind)
            ]
 #endif

--- a/Test/ReifyTypeSigs.hs
+++ b/Test/ReifyTypeSigs.hs
@@ -61,13 +61,14 @@ test_reify_kind_sigs =
                typeKind = DConT typeKindName
                boolKind = DConT ''Bool
                k_to_type = DArrowT `DAppT` DVarT k `DAppT` typeKind
-               forall_k_invis_k_to_type = DForallT ForallInvis [DPlainTV k] k_to_type in
+               forall_k_invis_k_to_type =
+                 DForallT (DForallInvis [DPlainTV k SpecifiedSpec]) k_to_type in
            [ (1, forall_k_invis_k_to_type)
            , (2, k_to_type)
            , (3, forall_k_invis_k_to_type)
            , (4, forall_k_invis_k_to_type)
            , (5, k_to_type)
-           , (6, DForallT ForallVis [DKindedTV k boolKind] $
+           , (6, DForallT (DForallVis [DKindedTV k () boolKind]) $
                  DArrowT `DAppT` (DConT ''Proxy `DAppT` DVarT k)
                          `DAppT` DConT ''Constraint)
            , (7, DArrowT `DAppT` boolKind `DAppT`

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -45,12 +45,12 @@ library
   build-depends:
       base >= 4.7 && < 5,
       ghc-prim,
-      template-haskell >= 2.9 && < 2.17,
+      template-haskell >= 2.9 && < 2.18,
       containers >= 0.5,
       mtl >= 2.1,
       ordered-containers >= 0.2.2,
       syb >= 0.4,
-      th-abstraction >= 0.2.11,
+      th-abstraction >= 0.4 && < 0.5,
       th-lift >= 0.6.1,
       th-orphans >= 0.13.7,
       transformers-compat >= 0.6.3
@@ -97,6 +97,7 @@ test-suite spec
       syb >= 0.4,
       HUnit >= 1.2,
       hspec >= 1.3,
+      th-abstraction >= 0.4 && < 0.5,
       th-desugar,
       th-lift >= 0.6.1,
       th-orphans >= 0.13.9


### PR DESCRIPTION
This adapts `th-desugar` to specificity-related changes in
`template-haskell-2.17.0.0`:

* `DTyVarBndr` now has a `flag` type parameter to indicate its
  specificity (if it has one). Type synonyms `DTyVarBndrSpec` (for
  type variable binders that have explicit specificities) and
  `DTyVarBndrUnit` (for type variable binders for which specificity
  is irrelevant) have been introduced.
* Constructors like `DData`, `DTySynD`, `DRuleP`, etc. have been
  updated to explicitly indicate that they take `DTyVarBndrUnit`s.
* The `ForallVisFlag` type has been removed in favor of
  `DForallTelescope`. Not only does this distinguish between visible
  and invisible `forall`s, it also records the fact that the type
  variable binders for visible `forall`s are `DTyVarBndrUnit`s, while
  the type variable binders for invisible `forall`s are
  `DTyVarBndrSpec`s.

Because this makes use of `Language.Haskell.TH.Datatype.TyVarBndr`,
a compatibility shim introduced in `th-abstraction-0.4`, this bumps
the lower version bounds on `th-abstraction` in `th-desugar.cabal`.

Fixes #140.