### PR TITLE
Final template-haskell-2.17–related changes (linear types and QualifiedDo)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.10
+# version: 0.10.3
 #
 version: ~> 1.0
 language: c
@@ -154,5 +154,5 @@ script:
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all
 
-# REGENDATA ("0.10",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.10.3",["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -23,7 +23,7 @@ import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Instances ()
 import Language.Haskell.TH.Lift
 
-$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''ForallVisFlag, ''DTyVarBndr
+$(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DForallTelescope, ''DTyVarBndr
                  , ''DMatch, ''DClause, ''DLetDec, ''DDec, ''DDerivClause, ''DCon
                  , ''DConFields, ''DForeign, ''DPragma, ''DRuleBndr, ''DTySynEqn
                  , ''DPatSynDir , ''NewOrData, ''DDerivStrategy
@@ -35,8 +35,12 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''ForallVisFlag, ''DTyVarBndr
 #if __GLASGOW_HASKELL__ < 801
                  , ''PatSynArgs
 #endif
+#if __GLASGOW_HASKELL__ < 900
+                 , ''Specificity
+#endif
 
                  , ''TypeArg,   ''DTypeArg
                  , ''FunArgs,   ''DFunArgs
                  , ''VisFunArg, ''DVisFunArg
+                 , ''ForallTelescope
                  ])

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -427,6 +427,8 @@ con_to_type h98_tvbs h98_result_ty con =
     (is_gadt, ty) | is_gadt   -> ty
                   | otherwise -> maybeForallT h98_tvbs [] ty
   where
+    -- Note that we deliberately ignore linear types and use (->) everywhere.
+    -- See [Gracefully handling linear types] in L.H.TH.Desugar.Core.
     go :: Con -> (Bool, Type) -- The Bool is True when dealing with a GADT
     go (NormalC _ stys)       = (False, mkArrows (map snd    stys)  h98_result_ty)
     go (RecC _ vstys)         = (False, mkArrows (map thdOf3 vstys) h98_result_ty)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ I will try to keep this package up-to-date with respect to changes in GHC.
 
 Known limitations
 -----------------
+
+## Limited support for kind inference
+
 `th-desugar` sometimes has to construct types for certain Haskell entities.
 For instance, `th-desugar` desugars all Haskell98-style constructors to use
 GADT syntax, so the following:
@@ -88,3 +91,12 @@ The following constructs are known to be susceptible to this issue:
 4. Locally reified data constructors
 5. Locally reified type family instances (on GHC 8.8 and later, in which the
    Template Haskell AST supports explicit `foralls` in type family equations)
+
+## Limited support for linear types
+
+Currently, the `th-desugar` AST deliberately makes it impossible to represent
+linear types, and desugaring a linear function arrow will simply turn into a
+normal function arrow `(->)`. This choice is partly motivated by issues in the
+way that linear types interact with Template Haskell, which sometimes make it
+impossible to tell whether a reified function type is linear or not. See, for
+instance, [GHC#18378](https://gitlab.haskell.org/ghc/ghc/-/issues/18378).

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -82,7 +82,7 @@ $(dsDecSplice S.dectest18)
 
 $(do decs <- S.rec_sel_test
      withLocalDeclarations decs $ do
-       [DDataD nd [] name [DPlainTV tvbName] k cons []] <- dsDecs decs
+       [DDataD nd [] name [DPlainTV tvbName ()] k cons []] <- dsDecs decs
        recsels <- getRecordSelectors cons
        let num_sels = length recsels `div` 2 -- ignore type sigs
        when (num_sels /= S.rec_sel_test_num_sels) $
@@ -95,5 +95,5 @@ $(do decs <- S.rec_sel_test
                  fields' = zip stricts types
              in
              DCon tvbs cxt con_name (DNormalC False fields') rty
-           plaindata = [DDataD nd [] name [DPlainTV tvbName] k (map unrecord cons) []]
+           plaindata = [DDataD nd [] name [DPlainTV tvbName ()] k (map unrecord cons) []]
        return (decsToTH plaindata ++ map letDecToTH recsels))

--- a/Test/ReifyTypeCUSKs.hs
+++ b/Test/ReifyTypeCUSKs.hs
@@ -96,7 +96,7 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
 #if __GLASGOW_HASKELL__ >= 800
            ++
            [ (8, let k = mkName "k" in
-                 DForallT ForallInvis [DPlainTV k] $
+                 DForallT (DForallInvis [DPlainTV k SpecifiedSpec]) $
                  DArrowT `DAppT` DVarT k `DAppT`
                    (DArrowT `DAppT` DVarT k `DAppT` typeKind))
            ]
@@ -105,19 +105,19 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
            ++
            [ (9, let j = mkName "j"
                      k = mkName "k" in
-                 DForallT ForallInvis [DPlainTV j] $
+                 DForallT (DForallInvis [DPlainTV j SpecifiedSpec]) $
                  DArrowT `DAppT` DVarT j `DAppT`
-                   (DForallT ForallInvis [DPlainTV k] $
+                   (DForallT (DForallInvis [DPlainTV k SpecifiedSpec]) $
                     DArrowT `DAppT` DVarT k `DAppT` typeKind))
            ]
 #endif
 #if __GLASGOW_HASKELL__ >= 809
            ++
            [ (10, let k = mkName "k" in
-                  DForallT ForallVis [DKindedTV k typeKind] $
+                  DForallT (DForallVis [DKindedTV k () typeKind]) $
                   DArrowT `DAppT` DVarT k `DAppT` typeKind)
            , (11, let k = mkName "k" in
-                  DForallT ForallVis [DPlainTV k] $
+                  DForallT (DForallVis [DPlainTV k ()]) $
                   DArrowT `DAppT` DVarT k `DAppT` typeKind)
            ]
 #endif

--- a/Test/ReifyTypeSigs.hs
+++ b/Test/ReifyTypeSigs.hs
@@ -61,13 +61,14 @@ test_reify_kind_sigs =
                typeKind = DConT typeKindName
                boolKind = DConT ''Bool
                k_to_type = DArrowT `DAppT` DVarT k `DAppT` typeKind
-               forall_k_invis_k_to_type = DForallT ForallInvis [DPlainTV k] k_to_type in
+               forall_k_invis_k_to_type =
+                 DForallT (DForallInvis [DPlainTV k SpecifiedSpec]) k_to_type in
            [ (1, forall_k_invis_k_to_type)
            , (2, k_to_type)
            , (3, forall_k_invis_k_to_type)
            , (4, forall_k_invis_k_to_type)
            , (5, k_to_type)
-           , (6, DForallT ForallVis [DKindedTV k boolKind] $
+           , (6, DForallT (DForallVis [DKindedTV k () boolKind]) $
                  DArrowT `DAppT` (DConT ''Proxy `DAppT` DVarT k)
                          `DAppT` DConT ''Constraint)
            , (7, DArrowT `DAppT` boolKind `DAppT`

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -531,7 +531,7 @@ $(return [])  -- somehow, this is necessary to get the staging correct for the
 normal_reifications :: [String]
 normal_reifications = $(do infos <- mapM reify reifyDecsNames
                            ListE <$> mapM (Syn.lift . show . Just)
-                                          (dropTrailing0s $ unqualify infos))
+                                          (dropTrailing0s $ delinearize $ unqualify infos))
 
 zipWith3M :: Monad m => (a -> b -> c -> m d) -> [a] -> [b] -> [c] -> m [d]
 zipWith3M f (a:as) (b:bs) (c:cs) = liftM2 (:) (f a b c) (zipWith3M f as bs cs)

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -40,6 +40,10 @@ rae@cs.brynmawr.edu
 {-# LANGUAGE StandaloneKindSignatures #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 900
+{-# LANGUAGE QualifiedDo #-}
+#endif
+
 {-# OPTIONS_GHC -fno-warn-missing-signatures -fno-warn-type-defaults
                 -fno-warn-name-shadowing #-}
 
@@ -311,6 +315,14 @@ test51_tuple_sections =
          f2 = (#,5,#)
      in case (#,#) (f1 "a" 'a') (f2 "b" 'b') of
           (#,#) ((,,) _ a _) ((#,,#) _ b _) -> a + b |]
+#endif
+
+#if __GLASGOW_HASKELL__ >= 900
+test52_qual_do =
+  [| P.do x <- [1, 2]
+          y@1 <- x
+          [1, 2]
+          P.return y |]
 #endif
 
 type family TFExpand x
@@ -748,5 +760,8 @@ test_exprs = [ test1_sections
 #endif
 #if __GLASGOW_HASKELL__ >= 809
              , test51_tuple_sections
+#endif
+#if __GLASGOW_HASKELL__ >= 900
+             , test52_qual_do
 #endif
              ]

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -79,6 +79,8 @@ library
 test-suite spec
   type:               exitcode-stdio-1.0
   ghc-options:        -Wall
+  if impl(ghc >= 8.6)
+    ghc-options:      -Wno-star-is-type
   default-language:   Haskell2010
   default-extensions: TemplateHaskell
   hs-source-dirs:     Test

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -45,12 +45,12 @@ library
   build-depends:
       base >= 4.7 && < 5,
       ghc-prim,
-      template-haskell >= 2.9 && < 2.17,
+      template-haskell >= 2.9 && < 2.18,
       containers >= 0.5,
       mtl >= 2.1,
       ordered-containers >= 0.2.2,
       syb >= 0.4,
-      th-abstraction >= 0.2.11,
+      th-abstraction >= 0.4 && < 0.5,
       th-lift >= 0.6.1,
       th-orphans >= 0.13.7,
       transformers-compat >= 0.6.3
@@ -97,6 +97,7 @@ test-suite spec
       syb >= 0.4,
       HUnit >= 1.2,
       hspec >= 1.3,
+      th-abstraction >= 0.4 && < 0.5,
       th-desugar,
       th-lift >= 0.6.1,
       th-orphans >= 0.13.9


### PR DESCRIPTION
This PR contains every commit that I needed to make `th-desugar` compile with `template-haskell-2.17.0.0`. In addition to the existing "Support explicit specificity" commit from #142, this includes two other commit:

* Deal with linear types–related changes in TH (which fixes #143)
* Add support for QualifiedDo 

Refer to each commit for an overview of what it does. Since each commit is relatively small, I decided to lump them into a single PR.

Subsumes #142.