### PR TITLE
Simplify the desugaring of lambda expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,11 @@ Version 1.12 [????.??.??]
   -substTyVarBndrs :: Quasi q => DSubst -> [DTyVarBndr flag] -> (DSubst -> [DTyVarBndr flag] -> q a) -> q a
   +substTyVarBndrs :: Quasi q => DSubst -> [DTyVarBndr flag] -> q (DSubst, [DTyVarBndr flag])
   ```
+* `mkDLamEFromDPats` has now generates slightly more direct code for certain
+  lambda expressions with `@`-patterns. For example, `\x@y -> f x y` would
+  previously desugar to `\arg -> case arg of { y -> let x = y in f x y }`, but
+  it now desugars to `\y -> let x = y in f x y`.
+* `mkDLamEFromDPats` now requires only a `Quasi` context instead of `DsMonad`.
 
 Version 1.11 [2020.03.25]
 -------------------------


### PR DESCRIPTION
`th-desugar`'s previous implementation was needlessly confusing, as there were no fewer than three functions that desugared lambda expressions in some way. This patch rips out two of those functions to leave `mkDLamEFromDPats` as the sole entrypoint for desugaring lambda expressions. This has some knock-on benefits:

* `mkDLamEFromDPats` now accepts a more general `Quasi` context rather than `DsMonad`.
* `mkDLamEFromDPats` now generates more direct code for certain lambda expressions that use `@`-patterns. For example, `\x@y -> f x y` would previously desugar to `\arg -> case arg of { y -> let x = y in f x y }`, but it now desugars to `\y -> let x = y in f x y`. This fixes #149.