### PR TITLE
Support VTA in data constructor patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 `th-desugar` release notes
 ==========================
 
+Version 1.13 [????.??.??]
+-------------------------
+* Support GHC 9.2.
+* Add support for visible type application in data constructor patterns. As a
+  result of these changes, the `DConP` constructor now has an extra field to
+  represent type arguments:
+
+  ```diff
+   data DPat
+     = ...
+  -  | DConP Name         [DPat] -- fun (Just    x) = ...
+  +  | DConP Name [DType] [DPat] -- fun (Just @t x) = ...
+     | ...
+  ```
+
 Version 1.12 [2021.03.12]
 -------------------------
 * Support GHC 9.0.

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -240,7 +240,7 @@ flattenDValD (DValD pat exp) = do
         DVarP n
           | n == name -> DVarP y
           | otherwise -> DWildP
-        DConP con ps -> DConP con (map (wildify name y) ps)
+        DConP con ts ps -> DConP con ts (map (wildify name y) ps)
         DTildeP pa -> DTildeP (wildify name y pa)
         DBangP pa -> DBangP (wildify name y pa)
         DSigP pa ty -> DSigP (wildify name y pa) ty
@@ -297,7 +297,7 @@ getRecordSelectors cons = merge_let_decs `fmap` concatMapM get_record_sels cons
             return $ concat
               [ [ DSigD name $ DForallT (DForallInvis con_tvbs)
                              $ DArrowT `DAppT` con_ret_ty `DAppT` field_ty
-                , DFunD name [DClause [DConP con_name
+                , DFunD name [DClause [DConP con_name []
                                          (mk_field_pats n (length fields) varName)]
                                       (DVarE varName)] ]
               | ((name, _strict, field_ty), n) <- zip fields [0..]

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -34,7 +34,7 @@ data DExp = DVarE Name
 -- | Corresponds to TH's @Pat@ type.
 data DPat = DLitP Lit
           | DVarP Name
-          | DConP Name [DPat]
+          | DConP Name [DType] [DPat]
           | DTildeP DPat
           | DBangP DPat
           | DSigP DPat DType

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -49,13 +49,13 @@ extractBoundNamesDPat :: DPat -> OSet Name
 extractBoundNamesDPat = go
   where
     go :: DPat -> OSet Name
-    go (DLitP _)      = OS.empty
-    go (DVarP n)      = OS.singleton n
-    go (DConP _ pats) = foldMap go pats
-    go (DTildeP p)    = go p
-    go (DBangP p)     = go p
-    go (DSigP p _)    = go p
-    go DWildP         = OS.empty
+    go (DLitP _)          = OS.empty
+    go (DVarP n)          = OS.singleton n
+    go (DConP _ tys pats) = foldMap fvDType tys <> foldMap go pats
+    go (DTildeP p)        = go p
+    go (DBangP p)         = go p
+    go (DSigP p _)        = go p
+    go DWildP             = OS.empty
 
 -----
 -- Binding forms

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -72,13 +72,17 @@ matchToTH :: DMatch -> Match
 matchToTH (DMatch pat exp) = Match (patToTH pat) (NormalB (expToTH exp)) []
 
 patToTH :: DPat -> Pat
-patToTH (DLitP lit)    = LitP lit
-patToTH (DVarP n)      = VarP n
-patToTH (DConP n pats) = ConP n (map patToTH pats)
-patToTH (DTildeP pat)  = TildeP (patToTH pat)
-patToTH (DBangP pat)   = BangP (patToTH pat)
-patToTH (DSigP pat ty) = SigP (patToTH pat) (typeToTH ty)
-patToTH DWildP         = WildP
+patToTH (DLitP lit)         = LitP lit
+patToTH (DVarP n)           = VarP n
+patToTH (DConP n _tys pats) = ConP n
+#if __GLASGOW_HASKELL__ >= 901
+                                   (map typeToTH _tys)
+#endif
+                                   (map patToTH pats)
+patToTH (DTildeP pat)       = TildeP (patToTH pat)
+patToTH (DBangP pat)        = BangP (patToTH pat)
+patToTH (DSigP pat ty)      = SigP (patToTH pat) (typeToTH ty)
+patToTH DWildP              = WildP
 
 decsToTH :: [DDec] -> [Dec]
 decsToTH = map decToTH

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -417,7 +417,11 @@ extractBoundNamesPat (LitP _)              = OS.empty
 extractBoundNamesPat (VarP name)           = OS.singleton name
 extractBoundNamesPat (TupP pats)           = foldMap extractBoundNamesPat pats
 extractBoundNamesPat (UnboxedTupP pats)    = foldMap extractBoundNamesPat pats
-extractBoundNamesPat (ConP _ pats)         = foldMap extractBoundNamesPat pats
+extractBoundNamesPat (ConP _
+#if __GLASGOW_HASKELL__ >= 901
+                             _
+#endif
+                               pats)       = foldMap extractBoundNamesPat pats
 extractBoundNamesPat (InfixP p1 _ p2)      = extractBoundNamesPat p1 `OS.union`
                                              extractBoundNamesPat p2
 extractBoundNamesPat (UInfixP p1 _ p2)     = extractBoundNamesPat p1 `OS.union`

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -45,12 +45,16 @@ $(S.dectest14)
 $(S.dectest15)
 #endif
 
+{-
+Temporarily disabled until #151 is addressed
+
 #if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
 $(S.dectest16)
 #endif
 #if __GLASGOW_HASKELL__ >= 802
 $(S.dectest17)
 #endif
+-}
 
 #if __GLASGOW_HASKELL__ >= 809
 $(S.dectest18)

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -69,12 +69,16 @@ $(dsDecSplice S.dectest14)
 $(dsDecSplice S.dectest15)
 #endif
 
+{-
+Temporarily disabled until #151 is addressed
+
 #if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
 $(return $ decsToTH [S.ds_dectest16])
 #endif
 #if __GLASGOW_HASKELL__ >= 802
 $(return $ decsToTH [S.ds_dectest17])
 #endif
+-}
 
 #if __GLASGOW_HASKELL__ >= 809
 $(dsDecSplice S.dectest18)

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -151,6 +151,9 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
 #if __GLASGOW_HASKELL__ >= 900
              , "qual_do"         ~: $test52_qual_do         @=? $(dsSplice test52_qual_do)
 #endif
+#if __GLASGOW_HASKELL__ >= 901
+             , "vta_in_con_pats" ~: $test53_vta_in_con_pats @=? $(dsSplice test53_vta_in_con_pats)
+#endif
              ]
 
 test35a = $test35_expand

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -325,6 +325,14 @@ test52_qual_do =
           P.return y |]
 #endif
 
+#if __GLASGOW_HASKELL__ >= 901
+test53_vta_in_con_pats =
+  [| let f :: Maybe Int -> Int
+         f (Just @Int x)  = x
+         f (Nothing @Int) = 42
+     in f (Just @Int 27) |]
+#endif
+
 type family TFExpand x
 type instance TFExpand Int = Bool
 type instance TFExpand (Maybe a) = [a]

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -1,5 +1,5 @@
 name:           th-desugar
-version:        1.12
+version:        1.13
 cabal-version:  >= 1.10
 synopsis:       Functions to desugar Template Haskell
 homepage:       https://github.com/goldfirere/th-desugar


### PR DESCRIPTION
The change at the heart of this patch involves `DConP`:

```diff
 data DPat
   = ...
-  | DConP Name         [DPat] -- fun (Just    x) = ...
+  | DConP Name [DType] [DPat] -- fun (Just @t x) = ...
   | ...
```

All other changes in this patch are a result of this.

Since this is a breaking change, I took the opportunity to bump the major version number to 1.13.

Addresses one bullet point of #148.