### PR TITLE
Don't sweeten top-level foralls in DInstanceD/DStandaloneDerivD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@ Version 1.13 [????.??.??]
   +  | DConP Name [DType] [DPat] -- fun (Just @t x) = ...
      | ...
   ```
+* The `Maybe [DTyVarBndrUnit]` fields in `DInstanceD` and `DStandaloneDerivD`
+  are no longer used when sweetening. Previously, `th-desugar` would attempt to
+  sweeten these `DTyVarBndrUnit`s by turning them into a nested `ForallT`, but
+  GHC 9.2 or later no longer allow this, as they forbid nested `forall`s in
+  instance heads entirely. As a result, the `Maybe [DTyVarBndrUnit]` fields are
+  now only useful for functions that consume `DDec`s directly.
 
 Version 1.12 [2021.03.12]
 -------------------------

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -113,6 +113,9 @@ data DDec = DLetDec DLetDec
           | DDataD NewOrData DCxt Name [DTyVarBndrUnit] (Maybe DKind) [DCon] [DDerivClause]
           | DTySynD Name [DTyVarBndrUnit] DType
           | DClassD DCxt Name [DTyVarBndrUnit] [FunDep] [DDec]
+            -- | Note that the @Maybe [DTyVarBndrUnit]@ field is dropped
+            -- entirely when sweetened, so it is only useful for functions
+            -- that directly consume @DDec@s.
           | DInstanceD (Maybe Overlap) (Maybe [DTyVarBndrUnit]) DCxt DType [DDec]
           | DForeignD DForeign
           | DOpenTypeFamilyD DTypeFamilyHead
@@ -122,6 +125,9 @@ data DDec = DLetDec DLetDec
                        [DCon] [DDerivClause]
           | DTySynInstD DTySynEqn
           | DRoleAnnotD Name [Role]
+            -- | Note that the @Maybe [DTyVarBndrUnit]@ field is dropped
+            -- entirely when sweetened, so it is only useful for functions
+            -- that directly consume @DDec@s.
           | DStandaloneDerivD (Maybe DDerivStrategy) (Maybe [DTyVarBndrUnit]) DCxt DType
           | DDefaultSigD Name DType
           | DPatSynD Name PatSynArgs DPatSynDir DPat

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -45,16 +45,12 @@ $(S.dectest14)
 $(S.dectest15)
 #endif
 
-{-
-Temporarily disabled until #151 is addressed
-
 #if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
 $(S.dectest16)
 #endif
 #if __GLASGOW_HASKELL__ >= 802
 $(S.dectest17)
 #endif
--}
 
 #if __GLASGOW_HASKELL__ >= 809
 $(S.dectest18)

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -69,16 +69,12 @@ $(dsDecSplice S.dectest14)
 $(dsDecSplice S.dectest15)
 #endif
 
-{-
-Temporarily disabled until #151 is addressed
-
 #if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
 $(return $ decsToTH [S.ds_dectest16])
 #endif
 #if __GLASGOW_HASKELL__ >= 802
 $(return $ decsToTH [S.ds_dectest17])
 #endif
--}
 
 #if __GLASGOW_HASKELL__ >= 809
 $(dsDecSplice S.dectest18)

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -453,6 +453,14 @@ class ExCls a
 data ExData1 a
 data ExData2 a
 
+-- ds_dectest{16,17} demonstrate instance declarations with outermost foralls,
+-- a feature which Template Haskell itself does not yet support (see #151).
+-- For this reason, the closest we can get to this in TH is to construct
+-- equivalent Decs, dectest{16,17}, that drop the outermost foralls. The test
+-- suite ensures that this process happens automatically during sweetening by
+-- checking that the sweetened versions of ds_dectest{16,17} equal
+-- dectest{16,17}.
+
 ds_dectest16 = DInstanceD Nothing (Just [DPlainTV (mkName "a") ()]) []
                 (DConT ''ExCls `DAppT`
                   (DConT ''ExData1 `DAppT` DVarT (mkName "a"))) []
@@ -461,9 +469,8 @@ dectest16 = return [ InstanceD
 #if __GLASGOW_HASKELL__ >= 800
                        Nothing
 #endif
-                       [] (ForallT [plainTVSpecified (mkName "a")] []
-                                   (ConT ''ExCls `AppT`
-                                     (ConT ''ExData1 `AppT` VarT (mkName "a")))) [] ]
+                       [] (ConT ''ExCls `AppT`
+                            (ConT ''ExData1 `AppT` VarT (mkName "a"))) [] ]
 ds_dectest17 = DStandaloneDerivD Nothing (Just [DPlainTV (mkName "a") ()]) []
                 (DConT ''ExCls `DAppT`
                   (DConT ''ExData2 `DAppT` DVarT (mkName "a")))
@@ -473,9 +480,8 @@ dectest17 = return [ StandaloneDerivD
 #if __GLASGOW_HASKELL__ >= 802
                        Nothing
 #endif
-                       [] (ForallT [plainTVSpecified (mkName "a")] []
-                                   (ConT ''ExCls `AppT`
-                                     (ConT ''ExData2 `AppT` VarT (mkName "a")))) ]
+                       [] (ConT ''ExCls `AppT`
+                            (ConT ''ExData2 `AppT` VarT (mkName "a"))) ]
 #endif
 
 #if __GLASGOW_HASKELL__ >= 809


### PR DESCRIPTION
GHC 9.2 does not like `th-desugar`'s current approach of sweetening the `Maybe [DTyVarBndrUnit]` fields of `DInstanceD`/`DStandaloneDerivD` to nested `ForallT`s. As a result, let's just not sweeten them at all until Template Haskell has a better story for outermost `forall`s in instance declarations.

Resolves #151.