### PR TITLE
Desugar non-exhaustive case expressions using `mkErrorMatchExpr`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 `th-desugar` release notes
 ==========================
 
+Version next [????.??.??]
+-------------------------
+* Fix an inconsistency which caused non-exhaustive `case` expressions to be
+  desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
+  desugared into code that throws a "`Non-exhaustive patterns in...`" error at
+  runtime, just as all other forms of non-exhaustive expressions are desugared.
+
 Version 1.13 [2021.10.30]
 -------------------------
 * Support GHC 9.2.

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -346,7 +346,7 @@ dsMatches scr = go
     go [] = return []
     go (Match pat body where_decs : rest) = do
       rest' <- go rest
-      let failure = DCaseE (DVarE scr) rest'  -- this might be an empty case.
+      let failure = maybeDCaseE CaseAlt (DVarE scr) rest'
       exp' <- dsBody body where_decs failure
       (pat', exp'') <- dsPatOverExp pat exp'
       uni_pattern <- isUniversalPattern pat' -- incomplete attempt at #6
@@ -1181,6 +1181,8 @@ data MatchContext
     -- ^ A record update
   | MultiWayIfAlt
     -- ^ Guards in a multi-way if alternative
+  | CaseAlt
+    -- ^ Patterns and guards in a case alternative
 
 -- | Construct an expression that throws an error when encountering a pattern
 -- at runtime that is not covered by pattern matching.
@@ -1194,6 +1196,7 @@ mkErrorMatchExpr mc =
         LetDecRhs pat -> pprint pat
         RecUpd        -> "record update"
         MultiWayIfAlt -> "multi-way if"
+        CaseAlt       -> "case"
 
 -- | Desugar a type
 dsType :: DsMonad q => Type -> q DType

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -29,7 +29,7 @@ import Language.Haskell.TH.Instances ()
 import Language.Haskell.TH.Syntax
 
 import Language.Haskell.TH.Desugar.AST
-import Language.Haskell.TH.Desugar.Core
+import Language.Haskell.TH.Desugar.Core (dsReify, maybeDLetE, mkTupleDExp)
 import Language.Haskell.TH.Desugar.FV
 import qualified Language.Haskell.TH.Desugar.OSet as OS
 import Language.Haskell.TH.Desugar.Util

--- a/Test/T159Decs.hs
+++ b/Test/T159Decs.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+
+-- | Defines two non-exhaustive functions that roundtrip through desugaring
+-- and sweetening. Both of these functions should desugar to definitions that
+-- throw a runtime exception before forcing their argument.
+--
+-- Because these functions are non-exhaustive (and therefore emit warnings), we
+-- put them in their own module so that we can disable the appropriate warnings
+-- without needing to disable the warnings globally.
+module T159Decs
+  ( t159A, t159B
+  ) where
+
+import Splices ( dsDecSplice )
+
+$(dsDecSplice [d| t159A, t159B :: () -> IO ()
+                  t159A x | False = return ()
+                  t159B x = case x of y | False -> return ()
+                |])

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -92,6 +92,7 @@ test-suite spec
                       ReifyTypeCUSKs
                       ReifyTypeSigs
                       Splices
+                      T159Decs
 
   build-depends:
       base >= 4 && < 5,


### PR DESCRIPTION
This makes desugaring non-exhaustive `case` expressions consistent with `th-desugar`'s treatment of all other forms of non-exhaustive expressions.

Fixes #159.