### PR TITLE
Don't apply type-variable hack when expanding closed type families

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Version next [????.??.??]
   desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
   desugared into code that throws a "`Non-exhaustive patterns in...`" error at
   runtime, just as all other forms of non-exhaustive expressions are desugared.
+* Fix a bug in which `expandType` would not expand closed type families when
+  applied to arguments containing type variables.
 
 Version 1.13 [2021.10.30]
 -------------------------

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -186,6 +186,8 @@ test_e8b = $(test_expand8 >>= dsExp >>= expandUnsoundly >>= return . expToTH)
 test_e9a = $test_expand9  -- requires GHC #9262
 test_e9b = $(test_expand9 >>= dsExp >>= expand >>= return . expToTH)
 #endif
+test_e10a = $test_expand10
+test_e10b = $(test_expand10 >>= dsExp >>= expand >>= return . expToTH)
 
 hasSameType :: a -> a -> Bool
 hasSameType _ _ = True
@@ -206,6 +208,7 @@ test_expand = and [ hasSameType test35a test35b
 #if __GLASGOW_HASKELL__ >= 709
                   , hasSameType test_e9a test_e9b
 #endif
+                  , hasSameType test_e10a test_e10b
                   ]
 
 test_dec :: [Bool]

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -392,6 +392,13 @@ test_expand9 = [| let f :: TFExpand (Maybe (IO a)) -> IO ()
                   f |]
 #endif
 
+type family TFExpandClosed a where
+  TFExpandClosed (Maybe a) = [a]
+
+test_expand10 = [| let f :: TFExpandClosed (Maybe (IO a)) -> IO ()
+                       f actions = sequence_ actions in
+                   f |]
+
 #if __GLASGOW_HASKELL__ >= 709
 test37_pred = [| let f :: (Read a, (Show a, Num a)) => a -> a
                      f x = read (show x) + x in


### PR DESCRIPTION
`th-desugar`'s type expansion machinery contains a workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/9262 that prevents `reifyInstances` from failing when the argument types contain type variables. This workaround was applied to both open and closed type families alike. While open type families certainly need the workaround, as their instances must be queried using `reifyInstances`, the workaround isn't necessary at all for closed type families, where all of the equations are immediately accessible.

This patch removes the workaround for closed type families and improves the documentation around the workaround to make it more obvious why it exists.

Fixes #161.