### PR TITLE
Require GHC 8.0 or later

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -68,16 +68,6 @@ jobs:
             compilerVersion: 8.0.2
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
 `th-desugar` release notes
 ==========================
 
-Version next [????.??.??]
+Version 1.14 [????.??.??]
 -------------------------
+* Drop support for GHC 7.8 and 7.10. As a consequence of this, the
+  `strictToBang` was removed as it no longer serves a useful purpose.
 * Fix an inconsistency which caused non-exhaustive `case` expressions to be
   desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
   desugared into code that throws a "`Non-exhaustive patterns in...`" error at

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -51,9 +51,7 @@ module Language.Haskell.TH.Desugar (
   DerivingClause, dsDerivClause, dsLetDec,
   dsMatches, dsBody, dsGuards, dsDoStmts, dsComp, dsClauses,
   dsBangType, dsVarBangType,
-#if __GLASGOW_HASKELL__ > 710
   dsTypeFamilyHead, dsFamilyResultSig,
-#endif
 #if __GLASGOW_HASKELL__ >= 801
   dsPatSynDir,
 #endif
@@ -97,10 +95,7 @@ module Language.Haskell.TH.Desugar (
   tupleDegree_maybe, tupleNameDegree_maybe,
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   unboxedTupleDegree_maybe, unboxedTupleNameDegree_maybe,
-  strictToBang, isTypeKindName, typeKindName,
-#if __GLASGOW_HASKELL__ >= 800
-  bindIP,
-#endif
+  isTypeKindName, typeKindName, bindIP,
   mkExtraDKindBinders, dTyVarBndrToDType, changeDTVFlags, toposortTyVarsOf,
 
   -- ** 'FunArgs' and 'VisFunArg'
@@ -139,10 +134,6 @@ import Data.Function
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Prelude hiding ( exp )
-
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
 
 -- | This class relates a TH type with its th-desugar type and allows
 -- conversions back and forth. The functional dependency goes only one

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -137,11 +137,6 @@ data DDec = DLetDec DLetDec
               -- signatures can only appear on the top level.
           deriving (Eq, Show, Typeable, Data, Generic)
 
-#if __GLASGOW_HASKELL__ < 711
-data Overlap = Overlappable | Overlapping | Overlaps | Incoherent
-  deriving (Eq, Ord, Show, Typeable, Data, Generic)
-#endif
-
 -- | Corresponds to TH's 'PatSynDir' type
 data DPatSynDir = DUnidir              -- ^ @pattern P x {<-} p@
                 | DImplBidir           -- ^ @pattern P x {=} p@
@@ -170,11 +165,6 @@ data DFamilyResultSig = DNoSig
                       | DKindSig DKind
                       | DTyVarSig DTyVarBndrUnit
                       deriving (Eq, Show, Typeable, Data, Generic)
-
-#if __GLASGOW_HASKELL__ <= 710
-data InjectivityAnn = InjectivityAnn Name [Name]
-  deriving (Eq, Ord, Show, Typeable, Data, Generic)
-#endif
 
 -- | Corresponds to TH's 'Con' type. Unlike 'Con', all 'DCon's reflect GADT
 -- syntax. This is beneficial for @th-desugar@'s since it means
@@ -250,24 +240,6 @@ type DBangType = (Bang, DType)
 
 -- | Corresponds to TH's @VarBangType@ type.
 type DVarBangType = (Name, Bang, DType)
-
-#if __GLASGOW_HASKELL__ <= 710
--- | Corresponds to TH's definition
-data SourceUnpackedness = NoSourceUnpackedness
-                        | SourceNoUnpack
-                        | SourceUnpack
-  deriving (Eq, Ord, Show, Typeable, Data, Generic)
-
--- | Corresponds to TH's definition
-data SourceStrictness = NoSourceStrictness
-                      | SourceLazy
-                      | SourceStrict
-  deriving (Eq, Ord, Show, Typeable, Data, Generic)
-
--- | Corresponds to TH's definition
-data Bang = Bang SourceUnpackedness SourceStrictness
-  deriving (Eq, Ord, Show, Typeable, Data, Generic)
-#endif
 
 -- | Corresponds to TH's @Foreign@ type.
 data DForeign = DImportF Callconv Safety String Name DType

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -28,7 +28,7 @@ data DExp = DVarE Name
           | DLetE [DLetDec] DExp
           | DSigE DExp DType
           | DStaticE DExp
-          deriving (Eq, Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Data, Generic)
 
 
 -- | Corresponds to TH's @Pat@ type.
@@ -39,7 +39,7 @@ data DPat = DLitP Lit
           | DBangP DPat
           | DSigP DPat DType
           | DWildP
-          deriving (Eq, Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @Type@ type, used to represent
 -- types and kinds.
@@ -53,7 +53,7 @@ data DType = DForallT DForallTelescope DType
            | DArrowT
            | DLitT TyLit
            | DWildCardT
-           deriving (Eq, Show, Typeable, Data, Generic)
+           deriving (Eq, Show, Data, Generic)
 
 -- | The type variable binders in a @forall@.
 data DForallTelescope
@@ -64,7 +64,7 @@ data DForallTelescope
   | DForallInvis [DTyVarBndrSpec]
     -- ^ An invisible @forall@ (e.g., @forall a {b} c -> {...}@),
     --   where each binder has a 'Specificity'.
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 
 -- | Kinds are types. Corresponds to TH's @Kind@
 type DKind = DType
@@ -79,7 +79,7 @@ type DCxt = [DPred]
 data DTyVarBndr flag
   = DPlainTV Name flag
   | DKindedTV Name flag DKind
-  deriving (Eq, Show, Typeable, Data, Generic, Functor)
+  deriving (Eq, Show, Data, Generic, Functor)
 
 -- | Corresponds to TH's @TyVarBndrSpec@
 type DTyVarBndrSpec = DTyVarBndr Specificity
@@ -89,11 +89,11 @@ type DTyVarBndrUnit = DTyVarBndr ()
 
 -- | Corresponds to TH's @Match@ type.
 data DMatch = DMatch DPat DExp
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @Clause@ type.
 data DClause = DClause [DPat] DExp
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 
 -- | Declarations as used in a @let@ statement.
 data DLetDec = DFunD Name [DClause]
@@ -101,12 +101,12 @@ data DLetDec = DFunD Name [DClause]
              | DSigD Name DType
              | DInfixD Fixity Name
              | DPragmaD DPragma
-             deriving (Eq, Show, Typeable, Data, Generic)
+             deriving (Eq, Show, Data, Generic)
 
 -- | Is it a @newtype@ or a @data@ type?
 data NewOrData = Newtype
                | Data
-               deriving (Eq, Show, Typeable, Data, Generic)
+               deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @Dec@ type.
 data DDec = DLetDec DLetDec
@@ -135,13 +135,13 @@ data DDec = DLetDec DLetDec
           | DKiSigD Name DKind
               -- DKiSigD is part of DDec, not DLetDec, because standalone kind
               -- signatures can only appear on the top level.
-          deriving (Eq, Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's 'PatSynDir' type
 data DPatSynDir = DUnidir              -- ^ @pattern P x {<-} p@
                 | DImplBidir           -- ^ @pattern P x {=} p@
                 | DExplBidir [DClause] -- ^ @pattern P x {<-} p where P x = e@
-                deriving (Eq, Show, Typeable, Data, Generic)
+                deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's 'PatSynType' type
 type DPatSynType = DType
@@ -152,19 +152,19 @@ data PatSynArgs
   = PrefixPatSyn [Name]        -- ^ @pattern P {x y z} = p@
   | InfixPatSyn Name Name      -- ^ @pattern {x P y} = p@
   | RecordPatSyn [Name]        -- ^ @pattern P { {x,y,z} } = p@
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 #endif
 
 -- | Corresponds to TH's 'TypeFamilyHead' type
 data DTypeFamilyHead = DTypeFamilyHead Name [DTyVarBndrUnit] DFamilyResultSig
                                        (Maybe InjectivityAnn)
-                     deriving (Eq, Show, Typeable, Data, Generic)
+                     deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's 'FamilyResultSig' type
 data DFamilyResultSig = DNoSig
                       | DKindSig DKind
                       | DTyVarSig DTyVarBndrUnit
-                      deriving (Eq, Show, Typeable, Data, Generic)
+                      deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's 'Con' type. Unlike 'Con', all 'DCon's reflect GADT
 -- syntax. This is beneficial for @th-desugar@'s since it means
@@ -183,13 +183,13 @@ data DFamilyResultSig = DNoSig
 -- * A 'DCon' always has an explicit return type.
 data DCon = DCon [DTyVarBndrSpec] DCxt Name DConFields
                  DType  -- ^ The GADT result type
-          deriving (Eq, Show, Typeable, Data, Generic)
+          deriving (Eq, Show, Data, Generic)
 
 -- | A list of fields either for a standard data constructor or a record
 -- data constructor.
 data DConFields = DNormalC DDeclaredInfix [DBangType]
                 | DRecC [DVarBangType]
-                deriving (Eq, Show, Typeable, Data, Generic)
+                deriving (Eq, Show, Data, Generic)
 
 -- | 'True' if a constructor is declared infix. For normal ADTs, this means
 -- that is was written in infix style. For example, both of the constructors
@@ -244,7 +244,7 @@ type DVarBangType = (Name, Bang, DType)
 -- | Corresponds to TH's @Foreign@ type.
 data DForeign = DImportF Callconv Safety String Name DType
               | DExportF Callconv String Name DType
-              deriving (Eq, Show, Typeable, Data, Generic)
+              deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @Pragma@ type.
 data DPragma = DInlineP Name Inline RuleMatch Phases
@@ -254,16 +254,16 @@ data DPragma = DInlineP Name Inline RuleMatch Phases
              | DAnnP AnnTarget DExp
              | DLineP Int String
              | DCompleteP [Name] (Maybe Name)
-             deriving (Eq, Show, Typeable, Data, Generic)
+             deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @RuleBndr@ type.
 data DRuleBndr = DRuleVar Name
                | DTypedRuleVar Name DType
-               deriving (Eq, Show, Typeable, Data, Generic)
+               deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @TySynEqn@ type (to store type family equations).
 data DTySynEqn = DTySynEqn (Maybe [DTyVarBndrUnit]) DType DType
-               deriving (Eq, Show, Typeable, Data, Generic)
+               deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @Info@ type.
 data DInfo = DTyConI DDec (Maybe [DInstanceDec])
@@ -276,17 +276,17 @@ data DInfo = DTyConI DDec (Maybe [DInstanceDec])
                -- ^ The @Int@ is the arity; the @Bool@ is whether this tycon
                -- is unlifted.
            | DPatSynI Name DPatSynType
-           deriving (Eq, Show, Typeable, Data, Generic)
+           deriving (Eq, Show, Data, Generic)
 
 type DInstanceDec = DDec -- ^ Guaranteed to be an instance declaration
 
 -- | Corresponds to TH's @DerivClause@ type.
 data DDerivClause = DDerivClause (Maybe DDerivStrategy) DCxt
-                  deriving (Eq, Show, Typeable, Data, Generic)
+                  deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @DerivStrategy@ type.
 data DDerivStrategy = DStockStrategy     -- ^ A \"standard\" derived instance
                     | DAnyclassStrategy  -- ^ @-XDeriveAnyClass@
                     | DNewtypeStrategy   -- ^ @-XGeneralizedNewtypeDeriving@
                     | DViaStrategy DType -- ^ @-XDerivingVia@
-                    deriving (Eq, Show, Typeable, Data, Generic)
+                    deriving (Eq, Show, Data, Generic)

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -7,7 +7,7 @@ Desugars full Template Haskell syntax into a smaller core syntax for further
 processing. The desugared types and constructors are prefixed with a D.
 -}
 
-{-# LANGUAGE TemplateHaskell, LambdaCase, CPP, ScopedTypeVariables,
+{-# LANGUAGE TemplateHaskellQuotes, LambdaCase, CPP, ScopedTypeVariables,
              TupleSections, DeriveDataTypeable, DeriveGeneric #-}
 
 module Language.Haskell.TH.Desugar.Core where

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -22,7 +22,7 @@ import Control.Monad hiding (forM_, mapM)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Zip
 import Control.Monad.Writer hiding (forM_, mapM)
-import Data.Data (Data, Typeable)
+import Data.Data (Data)
 import Data.Either (lefts)
 import Data.Foldable as F hiding (concat, notElem)
 import qualified Data.Map as M
@@ -1418,7 +1418,7 @@ applyDType = foldl apply
 data DTypeArg
   = DTANormal DType
   | DTyArg DKind
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 
 -- | Desugar a 'TypeArg'.
 dsTypeArg :: DsMonad q => TypeArg -> q DTypeArg
@@ -1620,7 +1620,7 @@ data DFunArgs
   | DFAAnon DType DFunArgs
     -- ^ An anonymous argument followed by an arrow. For example, the @a@
     --   in @a -> r@.
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 
 -- | A /visible/ function argument type (i.e., one that must be supplied
 -- explicitly in the source code). This is in contrast to /invisible/
@@ -1631,7 +1631,7 @@ data DVisFunArg
     -- ^ A visible @forall@ (e.g., @forall a -> a@).
   | DVisFAAnon DType
     -- ^ An anonymous argument followed by an arrow (e.g., @a -> r@).
-  deriving (Eq, Show, Typeable, Data, Generic)
+  deriving (Eq, Show, Data, Generic)
 
 -- | Filter the visible function arguments from a list of 'DFunArgs'.
 filterDVisFunArgs :: DFunArgs -> [DVisFunArg]

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -11,9 +11,6 @@ module Language.Haskell.TH.Desugar.FV
   , extractBoundNamesDPat
   ) where
 
-#if __GLASGOW_HASKELL__ < 710
-import Data.Foldable (foldMap)
-#endif
 #if __GLASGOW_HASKELL__ < 804
 import Data.Monoid ((<>))
 #endif

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -15,7 +15,7 @@
 ----------------------------------------------------------------------------
 
 {-# LANGUAGE CPP, TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Haskell.TH.Desugar.Lift () where
 

--- a/Language/Haskell/TH/Desugar/Lift.hs
+++ b/Language/Haskell/TH/Desugar/Lift.hs
@@ -28,10 +28,6 @@ $(deriveLiftMany [ ''DExp, ''DPat, ''DType, ''DForallTelescope, ''DTyVarBndr
                  , ''DConFields, ''DForeign, ''DPragma, ''DRuleBndr, ''DTySynEqn
                  , ''DPatSynDir , ''NewOrData, ''DDerivStrategy
                  , ''DTypeFamilyHead,  ''DFamilyResultSig
-#if __GLASGOW_HASKELL__ <= 710
-                 , ''InjectivityAnn, ''Bang, ''SourceUnpackedness
-                 , ''SourceStrictness, ''Overlap
-#endif
 #if __GLASGOW_HASKELL__ < 801
                  , ''PatSynArgs
 #endif

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -9,7 +9,7 @@ more nested patterns.
 This code is directly based on the analogous operation as written in GHC.
 -}
 
-{-# LANGUAGE CPP, TemplateHaskell #-}
+{-# LANGUAGE CPP, TemplateHaskellQuotes #-}
 
 module Language.Haskell.TH.Desugar.Match (scExp, scLetDec) where
 

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -15,9 +15,6 @@ module Language.Haskell.TH.Desugar.Match (scExp, scLetDec) where
 
 import Prelude hiding ( fail, exp )
 
-#if __GLASGOW_HASKELL__ < 709
-import Control.Applicative
-#endif
 import Control.Monad hiding ( fail )
 import qualified Control.Monad as Monad
 import Data.Data

--- a/Language/Haskell/TH/Desugar/OMap.hs
+++ b/Language/Haskell/TH/Desugar/OMap.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
@@ -71,7 +72,7 @@ instance Ord k => Monoid (OMap k v) where
 #endif
 
 empty :: forall k v. OMap k v
-empty = coerce (OM.empty :: OM.OMap k v)
+empty = coerce (OM.empty @k @v)
 
 singleton :: k -> v -> OMap k v
 singleton k v = coerce (OM.singleton (k, v))
@@ -87,55 +88,55 @@ insertPost :: Ord k => OMap k v -> k -> v -> OMap k v
 insertPost m k v = coerce (coerce m OM.|> (k, v))
 
 union :: forall k v. Ord k => OMap k v -> OMap k v -> OMap k v
-union = coerce ((OM.|<>) :: OM.OMap k v -> OM.OMap k v -> OM.OMap k v)
+union = coerce ((OM.|<>) @k @v)
 
 unionWithKey :: Ord k => (k -> v -> v -> v) -> OMap k v -> OMap k v -> OMap k v
 unionWithKey f = coerce (OM.unionWithL f)
 
 delete :: forall k v. Ord k => k -> OMap k v -> OMap k v
-delete = coerce (OM.delete :: k -> OM.OMap k v -> OM.OMap k v)
+delete = coerce (OM.delete @k @v)
 
 filterWithKey :: Ord k => (k -> v -> Bool) -> OMap k v -> OMap k v
 filterWithKey f = coerce (OM.filter f)
 
 (\\) :: forall k v v'. Ord k => OMap k v -> OMap k v' -> OMap k v
-(\\) = coerce ((OM.\\) :: OM.OMap k v -> OM.OMap k v' -> OM.OMap k v)
+(\\) = coerce ((OM.\\) @k @v @v')
 
 intersection :: forall k v v'. Ord k => OMap k v -> OMap k v' -> OMap k v
-intersection = coerce ((OM.|/\) :: OM.OMap k v -> OM.OMap k v' -> OM.OMap k v)
+intersection = coerce ((OM.|/\) @k @v @v')
 
 intersectionWithKey :: Ord k => (k -> v -> v' -> v'') -> OMap k v -> OMap k v' -> OMap k v''
 intersectionWithKey f = coerce (OM.intersectionWith f)
 
 null :: forall k v. OMap k v -> Bool
-null = coerce (OM.null :: OM.OMap k v -> Bool)
+null = coerce (OM.null @k @v)
 
 size :: forall k v. OMap k v -> Int
-size = coerce (OM.size :: OM.OMap k v -> Int)
+size = coerce (OM.size @k @v)
 
 member :: forall k v. Ord k => k -> OMap k v -> Bool
-member = coerce (OM.member :: k -> OM.OMap k v -> Bool)
+member = coerce (OM.member @k @v)
 
 notMember :: forall k v. Ord k => k -> OMap k v -> Bool
-notMember = coerce (OM.notMember :: k -> OM.OMap k v -> Bool)
+notMember = coerce (OM.notMember @k @v)
 
 lookup :: forall k v. Ord k => k -> OMap k v -> Maybe v
-lookup = coerce (OM.lookup :: k -> OM.OMap k v -> Maybe v)
+lookup = coerce (OM.lookup @k @v)
 
 lookupIndex :: forall k v. Ord k => k -> OMap k v -> Maybe Index
-lookupIndex = coerce (OM.findIndex :: k -> OM.OMap k v -> Maybe Index)
+lookupIndex = coerce (OM.findIndex @k @v)
 
 lookupAt :: forall k v. Index -> OMap k v -> Maybe (k, v)
-lookupAt i m = coerce (OM.elemAt (coerce m) i :: Maybe (k, v))
+lookupAt i m = OM.elemAt @k @v (coerce m) i
 
 fromList :: Ord k => [(k, v)] -> OMap k v
 fromList l = coerce (OM.fromList l)
 
 assocs :: forall k v. OMap k v -> [(k, v)]
-assocs = coerce (OM.assocs :: OM.OMap k v -> [(k, v)])
+assocs = coerce (OM.assocs @k @v)
 
 toAscList :: forall k v. OMap k v -> [(k, v)]
-toAscList = coerce (OM.toAscList :: OM.OMap k v -> [(k, v)])
+toAscList = coerce (OM.toAscList @k @v)
 
 toMap :: forall k v. OMap k v -> M.Map k v
-toMap = coerce (OM.toMap :: OM.OMap k v -> M.Map k v)
+toMap = coerce (OM.toMap @k @v)

--- a/Language/Haskell/TH/Desugar/OMap.hs
+++ b/Language/Haskell/TH/Desugar/OMap.hs
@@ -52,18 +52,8 @@ import Data.Map.Ordered (Bias(..), Index, L)
 import qualified Data.Map.Ordered as OM
 import Prelude hiding (filter, lookup, null)
 
-#if !(MIN_VERSION_base(4,8,0))
-import Data.Foldable (Foldable)
-import Data.Monoid (Monoid(..))
-import Data.Traversable (Traversable)
-#endif
-
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))
-#endif
-
-#if __GLASGOW_HASKELL__ < 710
-deriving instance Typeable L
 #endif
 
 -- | An ordered map whose 'insertPre', 'insertPost', 'intersection',

--- a/Language/Haskell/TH/Desugar/OMap.hs
+++ b/Language/Haskell/TH/Desugar/OMap.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/Language/Haskell/TH/Desugar/OMap.hs
+++ b/Language/Haskell/TH/Desugar/OMap.hs
@@ -60,7 +60,7 @@ import Data.Semigroup (Semigroup(..))
 -- 'intersectionWithKey', 'union', and 'unionWithKey' operations are biased
 -- towards leftmost indices when when breaking ties between keys.
 newtype OMap k v = OMap (Bias L (OM.OMap k v))
-  deriving (Data, Foldable, Functor, Eq, Ord, Read, Show, Traversable, Typeable)
+  deriving (Data, Foldable, Functor, Eq, Ord, Read, Show, Traversable)
 
 instance Ord k => Semigroup (OMap k v) where
   (<>) = union

--- a/Language/Haskell/TH/Desugar/OMap/Strict.hs
+++ b/Language/Haskell/TH/Desugar/OMap/Strict.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -44,7 +45,7 @@ import Language.Haskell.TH.Desugar.OMap (OMap(..))
 import Prelude hiding (filter, lookup, null)
 
 empty :: forall k v. OMap k v
-empty = coerce (OM.empty :: OM.OMap k v)
+empty = coerce (OM.empty @k @v)
 
 singleton :: k -> v -> OMap k v
 singleton k v = coerce (OM.singleton (k, v))
@@ -60,55 +61,55 @@ insertPost :: Ord k => OMap k v -> k -> v -> OMap k v
 insertPost m k v = coerce (coerce m OM.|> (k, v))
 
 union :: forall k v. Ord k => OMap k v -> OMap k v -> OMap k v
-union = coerce ((OM.|<>) :: OM.OMap k v -> OM.OMap k v -> OM.OMap k v)
+union = coerce ((OM.|<>) @k @v)
 
 unionWithKey :: Ord k => (k -> v -> v -> v) -> OMap k v -> OMap k v -> OMap k v
 unionWithKey f = coerce (OM.unionWithL f)
 
 delete :: forall k v. Ord k => k -> OMap k v -> OMap k v
-delete = coerce (OM.delete :: k -> OM.OMap k v -> OM.OMap k v)
+delete = coerce (OM.delete @k @v)
 
 filterWithKey :: Ord k => (k -> v -> Bool) -> OMap k v -> OMap k v
 filterWithKey f = coerce (OM.filter f)
 
 (\\) :: forall k v v'. Ord k => OMap k v -> OMap k v' -> OMap k v
-(\\) = coerce ((OM.\\) :: OM.OMap k v -> OM.OMap k v' -> OM.OMap k v)
+(\\) = coerce ((OM.\\) @k @v @v')
 
 intersection :: forall k v v'. Ord k => OMap k v -> OMap k v' -> OMap k v
-intersection = coerce ((OM.|/\) :: OM.OMap k v -> OM.OMap k v' -> OM.OMap k v)
+intersection = coerce ((OM.|/\) @k @v @v')
 
 intersectionWithKey :: Ord k => (k -> v -> v' -> v'') -> OMap k v -> OMap k v' -> OMap k v''
 intersectionWithKey f = coerce (OM.intersectionWith f)
 
 null :: forall k v. OMap k v -> Bool
-null = coerce (OM.null :: OM.OMap k v -> Bool)
+null = coerce (OM.null @k @v)
 
 size :: forall k v. OMap k v -> Int
-size = coerce (OM.size :: OM.OMap k v -> Int)
+size = coerce (OM.size @k @v)
 
 member :: forall k v. Ord k => k -> OMap k v -> Bool
-member = coerce (OM.member :: k -> OM.OMap k v -> Bool)
+member = coerce (OM.member @k @v)
 
 notMember :: forall k v. Ord k => k -> OMap k v -> Bool
-notMember = coerce (OM.notMember :: k -> OM.OMap k v -> Bool)
+notMember = coerce (OM.notMember @k @v)
 
 lookup :: forall k v. Ord k => k -> OMap k v -> Maybe v
-lookup = coerce (OM.lookup :: k -> OM.OMap k v -> Maybe v)
+lookup = coerce (OM.lookup @k @v)
 
 lookupIndex :: forall k v. Ord k => k -> OMap k v -> Maybe Index
-lookupIndex = coerce (OM.findIndex :: k -> OM.OMap k v -> Maybe Index)
+lookupIndex = coerce (OM.findIndex @k @v)
 
 lookupAt :: forall k v. Index -> OMap k v -> Maybe (k, v)
-lookupAt i m = coerce (OM.elemAt (coerce m) i :: Maybe (k, v))
+lookupAt i m = OM.elemAt @k @v (coerce m) i
 
 fromList :: Ord k => [(k, v)] -> OMap k v
 fromList l = coerce (OM.fromList l)
 
 assocs :: forall k v. OMap k v -> [(k, v)]
-assocs = coerce (OM.assocs :: OM.OMap k v -> [(k, v)])
+assocs = coerce (OM.assocs @k @v)
 
 toAscList :: forall k v. OMap k v -> [(k, v)]
-toAscList = coerce (OM.toAscList :: OM.OMap k v -> [(k, v)])
+toAscList = coerce (OM.toAscList @k @v)
 
 toMap :: forall k v. OMap k v -> M.Map k v
-toMap = coerce (OM.toMap :: OM.OMap k v -> M.Map k v)
+toMap = coerce (OM.toMap @k @v)

--- a/Language/Haskell/TH/Desugar/OSet.hs
+++ b/Language/Haskell/TH/Desugar/OSet.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -60,7 +61,7 @@ instance Ord a => Semigroup (OSet a) where
   (<>) = union
 
 empty :: forall a. OSet a
-empty = coerce (OS.empty :: OS.OSet a)
+empty = coerce (OS.empty @a)
 
 singleton :: a -> OSet a
 singleton a = coerce (OS.singleton a)
@@ -76,13 +77,13 @@ insertPost :: Ord a => OSet a -> a -> OSet a
 insertPost s a = coerce (coerce s OS.|> a)
 
 union :: forall a. Ord a => OSet a -> OSet a -> OSet a
-union = coerce ((OS.|<>) :: OS.OSet a -> OS.OSet a -> OS.OSet a)
+union = coerce ((OS.|<>) @a)
 
 null :: forall a. OSet a -> Bool
-null = coerce (OS.null :: OS.OSet a -> Bool)
+null = coerce (OS.null @a)
 
 size :: forall a. OSet a -> Int
-size = coerce (OS.size :: OS.OSet a -> Int)
+size = coerce (OS.size @a)
 
 member, notMember :: Ord a => a -> OSet a -> Bool
 member    a = coerce (OS.member a)
@@ -95,22 +96,22 @@ filter :: Ord a => (a -> Bool) -> OSet a -> OSet a
 filter f = coerce (OS.filter f)
 
 (\\) :: forall a. Ord a => OSet a -> OSet a -> OSet a
-(\\) = coerce ((OS.\\) :: OS.OSet a -> OS.OSet a -> OS.OSet a)
+(\\) = coerce ((OS.\\) @a)
 
 intersection :: forall a. Ord a => OSet a -> OSet a -> OSet a
-intersection = coerce ((OS.|/\) :: OS.OSet a -> OS.OSet a -> OS.OSet a)
+intersection = coerce ((OS.|/\) @a)
 
 lookupIndex :: Ord a => a -> OSet a -> Maybe Index
 lookupIndex a = coerce (OS.findIndex a)
 
 lookupAt :: forall a. Index -> OSet a -> Maybe a
-lookupAt i s = coerce (OS.elemAt (coerce s) i :: Maybe a)
+lookupAt i s = OS.elemAt @a (coerce s) i
 
 fromList :: Ord a => [a] -> OSet a
 fromList l = coerce (OS.fromList l)
 
 toAscList :: forall a. OSet a -> [a]
-toAscList = coerce (OS.toAscList :: OS.OSet a -> [a])
+toAscList = coerce (OS.toAscList @a)
 
 toSet :: forall a. OSet a -> S.Set a
-toSet = coerce (OS.toSet :: OS.OSet a -> S.Set a)
+toSet = coerce (OS.toSet @a)

--- a/Language/Haskell/TH/Desugar/OSet.hs
+++ b/Language/Haskell/TH/Desugar/OSet.hs
@@ -54,7 +54,7 @@ import Data.Semigroup (Semigroup(..))
 -- operations are biased towards leftmost indices when when breaking ties
 -- between keys.
 newtype OSet a = OSet (Bias L (OS.OSet a))
-  deriving (Data, Foldable, Eq, Monoid, Ord, Read, Show, Typeable)
+  deriving (Data, Foldable, Eq, Monoid, Ord, Read, Show)
 
 instance Ord a => Semigroup (OSet a) where
   (<>) = union

--- a/Language/Haskell/TH/Desugar/OSet.hs
+++ b/Language/Haskell/TH/Desugar/OSet.hs
@@ -46,11 +46,6 @@ import qualified Data.Set.Ordered as OS
 import Language.Haskell.TH.Desugar.OMap ()
 import Prelude hiding (filter, null)
 
-#if !(MIN_VERSION_base(4,8,0))
-import Data.Foldable (Foldable)
-import Data.Monoid (Monoid)
-#endif
-
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))
 #endif

--- a/Language/Haskell/TH/Desugar/Subst.hs
+++ b/Language/Haskell/TH/Desugar/Subst.hs
@@ -32,10 +32,6 @@ import Language.Haskell.TH.Desugar.AST
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Desugar.Util
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
-
 -- | A substitution is just a map from names to types
 type DSubst = M.Map Name DType
 

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -7,7 +7,7 @@ Converts desugared TH back into real TH.
 -}
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -55,11 +55,7 @@ expToTH (DLamE names exp)    = LamE (map VarP names) (expToTH exp)
 expToTH (DCaseE exp matches) = CaseE (expToTH exp) (map matchToTH matches)
 expToTH (DLetE decs exp)     = LetE (map letDecToTH decs) (expToTH exp)
 expToTH (DSigE exp ty)       = SigE (expToTH exp) (typeToTH ty)
-#if __GLASGOW_HASKELL__ < 709
-expToTH (DStaticE _)         = error "Static expressions supported only in GHC 7.10+"
-#else
 expToTH (DStaticE exp)       = StaticE (expToTH exp)
-#endif
 #if __GLASGOW_HASKELL__ >= 801
 expToTH (DAppTypeE exp ty)   = AppTypeE (expToTH exp) (typeToTH ty)
 #else
@@ -92,21 +88,11 @@ decsToTH = map decToTH
 decToTH :: DDec -> Dec
 decToTH (DLetDec d) = letDecToTH d
 decToTH (DDataD Data cxt n tvbs _mk cons derivings) =
-#if __GLASGOW_HASKELL__ > 710
   DataD (cxtToTH cxt) n (map tvbToTH tvbs) (fmap typeToTH _mk) (map conToTH cons)
         (concatMap derivClauseToTH derivings)
-#else
-  DataD (cxtToTH cxt) n (map tvbToTH tvbs) (map conToTH cons)
-        (map derivingToTH derivings)
-#endif
 decToTH (DDataD Newtype cxt n tvbs _mk [con] derivings) =
-#if __GLASGOW_HASKELL__ > 710
   NewtypeD (cxtToTH cxt) n (map tvbToTH tvbs) (fmap typeToTH _mk) (conToTH con)
            (concatMap derivClauseToTH derivings)
-#else
-  NewtypeD (cxtToTH cxt) n (map tvbToTH tvbs) (conToTH con)
-           (map derivingToTH derivings)
-#endif
 decToTH (DDataD Newtype _cxt _n _tvbs _mk _cons _derivings) =
   error "Newtype declaration without exactly 1 constructor."
 decToTH (DTySynD n tvbs ty) = TySynD n (map tvbToTH tvbs) (typeToTH ty)
@@ -116,19 +102,10 @@ decToTH (DInstanceD over _mtvbs cxt ty decs) =
   -- We deliberately avoid sweetening _mtvbs. See #151.
   instanceDToTH over cxt ty decs
 decToTH (DForeignD f) = ForeignD (foreignToTH f)
-#if __GLASGOW_HASKELL__ > 710
 decToTH (DOpenTypeFamilyD (DTypeFamilyHead n tvbs frs ann)) =
   OpenTypeFamilyD (TypeFamilyHead n (map tvbToTH tvbs) (frsToTH frs) ann)
-#else
-decToTH (DOpenTypeFamilyD (DTypeFamilyHead n tvbs frs _ann)) =
-  FamilyD TypeFam n (map tvbToTH tvbs) (frsToTH frs)
-#endif
 decToTH (DDataFamilyD n tvbs mk) =
-#if __GLASGOW_HASKELL__ > 710
   DataFamilyD n (map tvbToTH tvbs) (fmap typeToTH mk)
-#else
-  FamilyD DataFam n (map tvbToTH tvbs) (fmap typeToTH mk)
-#endif
 decToTH (DDataInstD nd cxt mtvbs lhs mk cons derivings) =
   let ndc = case (nd, cons) of
               (Newtype, [con]) -> DNewtypeCon con
@@ -142,24 +119,14 @@ decToTH (DTySynInstD eqn) =
   let (n, eqn') = tySynEqnToTH eqn in
   TySynInstD n eqn'
 #endif
-#if __GLASGOW_HASKELL__ > 710
 decToTH (DClosedTypeFamilyD (DTypeFamilyHead n tvbs frs ann) eqns) =
   ClosedTypeFamilyD (TypeFamilyHead n (map tvbToTH tvbs) (frsToTH frs) ann)
                     (map (snd . tySynEqnToTH) eqns)
-#else
-decToTH (DClosedTypeFamilyD (DTypeFamilyHead n tvbs frs _ann) eqns) =
-  ClosedTypeFamilyD n (map tvbToTH tvbs) (frsToTH frs) (map (snd . tySynEqnToTH) eqns)
-#endif
 decToTH (DRoleAnnotD n roles) = RoleAnnotD n roles
 decToTH (DStandaloneDerivD mds _mtvbs cxt ty) =
   -- We deliberately avoid sweetening _mtvbs. See #151.
   standaloneDerivDToTH mds cxt ty
-#if __GLASGOW_HASKELL__ < 709
-decToTH (DDefaultSigD {})      =
-  error "Default method signatures supported only in GHC 7.10+"
-#else
 decToTH (DDefaultSigD n ty)        = DefaultSigD n (typeToTH ty)
-#endif
 #if __GLASGOW_HASKELL__ >= 801
 decToTH (DPatSynD n args dir pat) = PatSynD n args (patSynDirToTH dir) (patToTH pat)
 decToTH (DPatSynSigD n ty)        = PatSynSigD n (typeToTH ty)
@@ -195,12 +162,9 @@ dataInstDecToTH ndc cxt _mtvbs lhs _mk derivings =
       NewtypeInstD (cxtToTH cxt) (fmap (fmap tvbToTH) _mtvbs) (typeToTH lhs)
                    (fmap typeToTH _mk) (conToTH con)
                    (concatMap derivClauseToTH derivings)
-#elif __GLASGOW_HASKELL__ > 710
+#else
       NewtypeInstD (cxtToTH cxt) _n _lhs_args (fmap typeToTH _mk) (conToTH con)
                    (concatMap derivClauseToTH derivings)
-#else
-      NewtypeInstD (cxtToTH cxt) _n _lhs_args (conToTH con)
-                   (map derivingToTH derivings)
 #endif
 
     DDataCons cons ->
@@ -208,12 +172,9 @@ dataInstDecToTH ndc cxt _mtvbs lhs _mk derivings =
       DataInstD (cxtToTH cxt) (fmap (fmap tvbToTH) _mtvbs) (typeToTH lhs)
                 (fmap typeToTH _mk) (map conToTH cons)
                 (concatMap derivClauseToTH derivings)
-#elif __GLASGOW_HASKELL__ > 710
+#else
       DataInstD (cxtToTH cxt) _n _lhs_args (fmap typeToTH _mk) (map conToTH cons)
                 (concatMap derivClauseToTH derivings)
-#else
-      DataInstD (cxtToTH cxt) _n _lhs_args (map conToTH cons)
-                (map derivingToTH derivings)
 #endif
   where
     _lhs' = typeToTH lhs
@@ -222,25 +183,10 @@ dataInstDecToTH ndc cxt _mtvbs lhs _mk derivings =
         (ConT n, lhs_args) -> (n, filterTANormals lhs_args)
         (_, _) -> error $ "Illegal data instance LHS: " ++ pprint _lhs'
 
-#if __GLASGOW_HASKELL__ > 710
 frsToTH :: DFamilyResultSig -> FamilyResultSig
 frsToTH DNoSig          = NoSig
 frsToTH (DKindSig k)    = KindSig (typeToTH k)
 frsToTH (DTyVarSig tvb) = TyVarSig (tvbToTH tvb)
-#else
-frsToTH :: DFamilyResultSig -> Maybe Kind
-frsToTH DNoSig                        = Nothing
-frsToTH (DKindSig k)                  = Just (typeToTH k)
-frsToTH (DTyVarSig (DPlainTV _ _))    = Nothing
-frsToTH (DTyVarSig (DKindedTV _ _ k)) = Just (typeToTH k)
-#endif
-
-#if __GLASGOW_HASKELL__ <= 710
-derivingToTH :: DDerivClause -> Name
-derivingToTH (DDerivClause _ [DConT nm]) = nm
-derivingToTH p =
-  error ("Template Haskell in GHC < 8.0 only allows simple derivings: " ++ show p)
-#endif
 
 -- | Sweeten a 'DLetDec'.
 letDecToTH :: DLetDec -> Dec
@@ -251,93 +197,27 @@ letDecToTH (DInfixD f name)     = InfixD f name
 letDecToTH (DPragmaD prag)      = PragmaD (pragmaToTH prag)
 
 conToTH :: DCon -> Con
-#if __GLASGOW_HASKELL__ > 710
 conToTH (DCon [] [] n (DNormalC _ stys) rty) =
   GadtC [n] (map (second typeToTH) stys) (typeToTH rty)
 conToTH (DCon [] [] n (DRecC vstys) rty) =
   RecGadtC [n] (map (thirdOf3 typeToTH) vstys) (typeToTH rty)
-#else
-conToTH (DCon [] [] n (DNormalC True [sty1, sty2]) _) =
-  InfixC ((bangToStrict *** typeToTH) sty1) n ((bangToStrict *** typeToTH) sty2)
--- Note: it's possible that someone could pass in a DNormalC value that
--- erroneously claims that it's declared infix (e.g., if has more than two
--- fields), but we will fall back on NormalC in such a scenario.
-conToTH (DCon [] [] n (DNormalC _ stys) _) =
-  NormalC n (map (bangToStrict *** typeToTH) stys)
-conToTH (DCon [] [] n (DRecC vstys) _) =
-  RecC n (map (\(v,b,t) -> (v,bangToStrict b,typeToTH t)) vstys)
-#endif
-#if __GLASGOW_HASKELL__ > 710
 -- On GHC 8.0 or later, we sweeten every constructor to GADT syntax, so it is
 -- perfectly OK to put all of the quantified type variables
 -- (both universal and existential) in a ForallC.
 conToTH (DCon tvbs cxt n fields rty) =
   ForallC (map tvbToTH tvbs) (cxtToTH cxt) (conToTH $ DCon [] [] n fields rty)
-#else
--- On GHCs earlier than 8.0, we must be careful, since the only time ForallC is
--- used is when there are either:
---
--- 1. Any existentially quantified type variables
--- 2. A constructor context
---
--- If neither of these conditions hold, then we needn't put a ForallC at the
--- front, since it would be completely pointless (you'd end up with things like
--- @data Foo = forall. MkFoo@!).
-conToTH (DCon tvbs cxt n fields rty)
-  | null ex_tvbs && null cxt
-  = con'
-  | otherwise
-  = ForallC ex_tvbs (cxtToTH cxt) con'
-  where
-    -- Fortunately, on old GHCs, it's especially easy to distinguish between
-    -- universally and existentially quantified type variables. When desugaring
-    -- a ForallC, we just stick all of the universals (from the datatype
-    -- definition) at the front of the @forall@. Therefore, it suffices to
-    -- count the number of type variables in the return type and drop that many
-    -- variables from the @forall@ in the ForallC, leaving only the
-    -- existentials.
-    ex_tvbs :: [TyVarBndr]
-    ex_tvbs = map tvbToTH $ drop num_univ_tvs tvbs
-
-    num_univ_tvs :: Int
-    num_univ_tvs = go rty
-      where
-        go :: DType -> Int
-        go (DAppT t1 t2) = go t1 + go t2
-        go (DSigT t _)   = go t
-        go (DVarT {})    = 1
-        go (DConT {})    = 0
-        go DArrowT       = 0
-        go (DLitT {})    = 0
-        -- These won't show up on pre-8.0 GHCs
-        go (DForallT {})      = error "`forall` type used in GADT return type"
-        go (DConstrainedT {}) = error "Constrained type used in GADT return type"
-        go DWildCardT         = 0
-        go (DAppKindT {})     = 0
-
-    con' :: Con
-    con' = conToTH $ DCon [] [] n fields rty
-#endif
 
 instanceDToTH :: Maybe Overlap -> DCxt -> DType -> [DDec] -> Dec
-instanceDToTH _over cxt ty decs =
-  InstanceD
-#if __GLASGOW_HASKELL__ >= 800
-            _over
-#endif
-            (cxtToTH cxt) (typeToTH ty) (decsToTH decs)
+instanceDToTH over cxt ty decs =
+  InstanceD over (cxtToTH cxt) (typeToTH ty) (decsToTH decs)
 
 standaloneDerivDToTH :: Maybe DDerivStrategy -> DCxt -> DType -> Dec
-#if __GLASGOW_HASKELL__ >= 710
 standaloneDerivDToTH _mds cxt ty =
   StandaloneDerivD
 #if __GLASGOW_HASKELL__ >= 802
                    (fmap derivStrategyToTH _mds)
 #endif
                    (cxtToTH cxt) (typeToTH ty)
-#else
-standaloneDerivDToTH _ _ _ = error "Standalone deriving supported only in GHC 7.10+"
-#endif
 
 foreignToTH :: DForeign -> Foreign
 foreignToTH (DImportF cc safety str n ty) =
@@ -358,11 +238,7 @@ pragmaToTH (DRuleP str _ rbs lhs rhs phases) =
   RuleP str (map ruleBndrToTH rbs) (expToTH lhs) (expToTH rhs) phases
 #endif
 pragmaToTH (DAnnP target exp) = AnnP target (expToTH exp)
-#if __GLASGOW_HASKELL__ < 709
-pragmaToTH (DLineP {}) = error "LINE pragmas only supported in GHC 7.10+"
-#else
 pragmaToTH (DLineP n str) = LineP n str
-#endif
 #if __GLASGOW_HASKELL__ < 801
 pragmaToTH (DCompleteP {}) = error "COMPLETE pragmas only supported in GHC 8.2+"
 #else
@@ -418,11 +294,7 @@ typeToTH (DVarT n)              = VarT n
 typeToTH (DConT n)              = tyconToTH n
 typeToTH DArrowT                = ArrowT
 typeToTH (DLitT lit)            = LitT lit
-#if __GLASGOW_HASKELL__ > 710
 typeToTH DWildCardT = WildCardT
-#else
-typeToTH DWildCardT = error "Wildcards supported only in GHC 8.0+"
-#endif
 #if __GLASGOW_HASKELL__ >= 807
 typeToTH (DAppKindT t k)        = AppKindT (typeToTH t) (typeToTH k)
 #else
@@ -467,44 +339,13 @@ patSynDirToTH (DExplBidir clauses) = ExplBidir (map clauseToTH clauses)
 #endif
 
 predToTH :: DPred -> Pred
-#if __GLASGOW_HASKELL__ < 709
-predToTH = go []
-  where
-    go acc (DAppT p t) = go (typeToTH t : acc) p
-    -- In the event that we're on a version of Template Haskell without support
-    -- for kind applications, we will simply drop the applied kind.
-    go acc (DAppKindT t _) = go acc t
-    go acc (DSigT p _) = go acc                p  -- this shouldn't happen.
-    go acc (DConT n)
-      | nameBase n == "~"
-      , [t1, t2] <- acc
-      = EqualP t1 t2
-      | otherwise
-      = ClassP n acc
-    go _   (DVarT _)
-      = error "Template Haskell in GHC <= 7.8 does not support variable constraints."
-    go _ DWildCardT
-      = error "Wildcards supported only in GHC 8.0+"
-    go _ (DForallT {})
-      = error "Quantified constraints supported only in GHC 8.6+"
-    go _ (DConstrainedT {})
-      = error "Quantified constraints supported only in GHC 8.6+"
-    go _ DArrowT
-      = error "(->) spotted at head of a constraint"
-    go _ (DLitT {})
-      = error "Type-level literal spotted at head of a constraint"
-#else
 predToTH (DAppT p t) = AppT (predToTH p) (typeToTH t)
 predToTH (DSigT p k) = SigT (predToTH p) (typeToTH k)
 predToTH (DVarT n)   = VarT n
 predToTH (DConT n)   = typeToTH (DConT n)
 predToTH DArrowT     = ArrowT
 predToTH (DLitT lit) = LitT lit
-#if __GLASGOW_HASKELL__ > 710
 predToTH DWildCardT  = WildCardT
-#else
-predToTH DWildCardT  = error "Wildcards supported only in GHC 8.0+"
-#endif
 #if __GLASGOW_HASKELL__ >= 805
 -- We need a special case for DForallT ForallInvis followed by DConstrainedT
 -- so that we may collapse them into a single ForallT when sweetening.
@@ -527,15 +368,12 @@ predToTH (DAppKindT p k) = AppKindT (predToTH p) (typeToTH k)
 -- kind applications, we will simply drop the applied kind.
 predToTH (DAppKindT p _) = predToTH p
 #endif
-#endif
 
 tyconToTH :: Name -> Type
 tyconToTH n
   | n == ''(->)                 = ArrowT -- Work around Trac #14888
   | n == ''[]                   = ListT
-#if __GLASGOW_HASKELL__ >= 709
   | n == ''(~)                  = EqualityT
-#endif
   | n == '[]                    = PromotedNilT
   | n == '(:)                   = PromotedConsT
   | Just deg <- tupleNameDegree_maybe n
@@ -555,11 +393,3 @@ tyconToTH n
 typeArgToTH :: DTypeArg -> TypeArg
 typeArgToTH (DTANormal t) = TANormal (typeToTH t)
 typeArgToTH (DTyArg k)    = TyArg    (typeToTH k)
-
-#if __GLASGOW_HASKELL__ <= 710
--- | Convert a 'Bang' to a 'Strict'
-bangToStrict :: Bang -> Strict
-bangToStrict (Bang SourceUnpack _) = Unpacked
-bangToStrict (Bang _ SourceStrict) = IsStrict
-bangToStrict (Bang _ _)            = NotStrict
-#endif

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -201,7 +201,7 @@ data ForallTelescope
   | ForallInvis [TyVarBndrSpec]
     -- ^ An invisible @forall@ (e.g., @forall a {b} c -> {...}@),
     --   where each binder has a 'Specificity'.
-  deriving (Eq, Show, Typeable, Data)
+  deriving (Eq, Show, Data)
 
 -- | The list of arguments in a function 'Type'.
 data FunArgs
@@ -217,7 +217,7 @@ data FunArgs
   | FAAnon Type FunArgs
     -- ^ An anonymous argument followed by an arrow. For example, the @a@
     --   in @a -> r@.
-  deriving (Eq, Show, Typeable, Data)
+  deriving (Eq, Show, Data)
 
 -- | A /visible/ function argument type (i.e., one that must be supplied
 -- explicitly in the source code). This is in contrast to /invisible/
@@ -228,7 +228,7 @@ data VisFunArg
     -- ^ A visible @forall@ (e.g., @forall a -> a@).
   | VisFAAnon Type
     -- ^ An anonymous argument followed by an arrow (e.g., @a -> r@).
-  deriving (Eq, Show, Typeable, Data)
+  deriving (Eq, Show, Data)
 
 -- | Filter the visible function arguments from a list of 'FunArgs'.
 filterVisFunArgs :: FunArgs -> [VisFunArg]
@@ -329,7 +329,7 @@ unfoldType = go []
 data TypeArg
   = TANormal Type
   | TyArg Kind
-  deriving (Eq, Show, Typeable, Data)
+  deriving (Eq, Show, Data)
 
 -- | Apply one 'Type' to a list of arguments.
 applyType :: Type -> [TypeArg] -> Type

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ decisions are based on that use case, when more than one design choice was
 possible.
 
 I will try to keep this package up-to-date with respect to changes in GHC.
+The minimum supported version of GHC is 8.0, which was chosen to avoid various
+Template Haskell bugs in older GHC versions that affect how this library
+desugars code. If this choice negatively impacts you, please submit a bug
+report.
 
 Known limitations
 -----------------

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -8,16 +8,10 @@ rae@cs.brynmawr.edu
              MultiParamTypeClasses, FunctionalDependencies,
              FlexibleInstances, DataKinds, CPP, RankNTypes,
              StandaloneDeriving, DefaultSignatures,
-             ConstraintKinds, RoleAnnotations #-}
-#if __GLASGOW_HASKELL__ >= 710
-{-# LANGUAGE DeriveAnyClass #-}
-#endif
+             ConstraintKinds, RoleAnnotations, DeriveAnyClass #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans -fno-warn-name-shadowing #-}
-
-#if __GLASGOW_HASKELL__ >= 711
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
+{-# OPTIONS_GHC -fno-warn-orphans -fno-warn-name-shadowing
+                -Wno-redundant-constraints #-}
 
 module Dec where
 
@@ -34,21 +28,15 @@ $(S.dectest7)
 $(S.dectest8)
 $(S.dectest9)
 $(S.dectest10)
-#if __GLASGOW_HASKELL__ >= 709
 $(S.dectest11)
-#endif
 $(S.dectest12)
 $(S.dectest13)
 $(S.dectest14)
 
-#if __GLASGOW_HASKELL__ >= 710
 $(S.dectest15)
-#endif
 
-#if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
-$(S.dectest16)
-#endif
 #if __GLASGOW_HASKELL__ >= 802
+$(S.dectest16)
 $(S.dectest17)
 #endif
 

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -10,7 +10,7 @@ rae@cs.brynmawr.edu
              StandaloneDeriving, DefaultSignatures,
              ConstraintKinds, RoleAnnotations, DeriveAnyClass #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans -fno-warn-name-shadowing
+{-# OPTIONS_GHC -Wno-orphans -Wno-name-shadowing
                 -Wno-redundant-constraints #-}
 
 module Dec where

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -13,8 +13,8 @@ rae@cs.brynmawr.edu
 {-# LANGUAGE DerivingStrategies #-}
 #endif
 
-{-# OPTIONS_GHC -fno-warn-orphans -fno-warn-incomplete-patterns
-                -fno-warn-name-shadowing -Wno-redundant-constraints #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-incomplete-patterns
+                -Wno-name-shadowing -Wno-redundant-constraints #-}
 
 module DsDec where
 

--- a/Test/DsDec.hs
+++ b/Test/DsDec.hs
@@ -8,20 +8,13 @@ rae@cs.brynmawr.edu
              MultiParamTypeClasses, FunctionalDependencies,
              FlexibleInstances, DataKinds, CPP, RankNTypes,
              StandaloneDeriving, DefaultSignatures,
-             ConstraintKinds, RoleAnnotations #-}
-#if __GLASGOW_HASKELL__ >= 710
-{-# LANGUAGE DeriveAnyClass #-}
-#endif
+             ConstraintKinds, RoleAnnotations, DeriveAnyClass #-}
 #if __GLASGOW_HASKELL__ >= 801
 {-# LANGUAGE DerivingStrategies #-}
 #endif
 
 {-# OPTIONS_GHC -fno-warn-orphans -fno-warn-incomplete-patterns
-                -fno-warn-name-shadowing #-}
-
-#if __GLASGOW_HASKELL__ >= 711
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
+                -fno-warn-name-shadowing -Wno-redundant-constraints #-}
 
 module DsDec where
 
@@ -52,10 +45,8 @@ $(dsDecSplice (fmap unqualify S.imp_inst_test4))
 
 $(dsDecSplice S.dectest10)
 
-#if __GLASGOW_HASKELL__ >= 709
 $(dsDecSplice S.dectest11)
 $(dsDecSplice S.standalone_deriving_test)
-#endif
 
 #if __GLASGOW_HASKELL__ >= 801
 $(dsDecSplice S.deriv_strat_test)
@@ -65,14 +56,10 @@ $(dsDecSplice S.dectest12)
 $(dsDecSplice S.dectest13)
 $(dsDecSplice S.dectest14)
 
-#if __GLASGOW_HASKELL__ >= 710
 $(dsDecSplice S.dectest15)
-#endif
 
-#if __GLASGOW_HASKELL__ < 800 || __GLASGOW_HASKELL__ >= 802
-$(return $ decsToTH [S.ds_dectest16])
-#endif
 #if __GLASGOW_HASKELL__ >= 802
+$(return $ decsToTH [S.ds_dectest16])
 $(return $ decsToTH [S.ds_dectest17])
 #endif
 

--- a/Test/ReifyTypeCUSKs.hs
+++ b/Test/ReifyTypeCUSKs.hs
@@ -3,9 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
-#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TypeInType #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 806
 {-# LANGUAGE StarIsType #-}
 #endif
@@ -16,11 +14,8 @@
 -- the -XCUSKs language extension.
 module ReifyTypeCUSKs where
 
-#if __GLASGOW_HASKELL__ >= 800 && __GLASGOW_HASKELL__ < 806
+#if __GLASGOW_HASKELL__ < 806
 import Data.Kind (type (*))
-#endif
-#if __GLASGOW_HASKELL__ < 710
-import Data.Traversable (traverse)
 #endif
 import GHC.Exts (Constraint)
 import Language.Haskell.TH.Desugar
@@ -39,9 +34,7 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
              class A6 (a :: *) where
                type A7 a b
 
-#if __GLASGOW_HASKELL__ >= 800
              data A8 (a :: k) :: k -> *
-#endif
 #if __GLASGOW_HASKELL__ >= 804
              data A9 (a :: j) :: forall k. k -> *
 #endif
@@ -62,9 +55,7 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
              class B6 a where
                type B7 (a :: *) (b :: *) :: *
 
-#if __GLASGOW_HASKELL__ >= 800
              data B8 :: k -> *
-#endif
 #if __GLASGOW_HASKELL__ >= 804
              data B9 :: forall j. j -> k -> *
 #endif
@@ -93,14 +84,12 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
            , (6, DArrowT `DAppT` typeKind `DAppT` DConT ''Constraint)
            , (7, DArrowT `DAppT` typeKind `DAppT` type_to_type)
            ]
-#if __GLASGOW_HASKELL__ >= 800
            ++
            [ (8, let k = mkName "k" in
                  DForallT (DForallInvis [DPlainTV k SpecifiedSpec]) $
                  DArrowT `DAppT` DVarT k `DAppT`
                    (DArrowT `DAppT` DVarT k `DAppT` typeKind))
            ]
-#endif
 #if __GLASGOW_HASKELL__ >= 804
            ++
            [ (9, let j = mkName "j"
@@ -127,9 +116,7 @@ test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
          traverse (test_reify_kind "B") $
            map (, Nothing) $
                 [1..7]
-#if __GLASGOW_HASKELL__ >= 800
              ++ [8]
-#endif
 #if __GLASGOW_HASKELL__ >= 804
              ++ [9]
 #endif

--- a/Test/ReifyTypeCUSKs.hs
+++ b/Test/ReifyTypeCUSKs.hs
@@ -4,9 +4,6 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeInType #-}
-#if __GLASGOW_HASKELL__ >= 806
-{-# LANGUAGE StarIsType #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 809
 {-# LANGUAGE CUSKs #-}
 #endif
@@ -14,50 +11,48 @@
 -- the -XCUSKs language extension.
 module ReifyTypeCUSKs where
 
-#if __GLASGOW_HASKELL__ < 806
-import Data.Kind (type (*))
-#endif
+import Data.Kind (Type)
 import GHC.Exts (Constraint)
 import Language.Haskell.TH.Desugar
-import Language.Haskell.TH.Syntax
+import Language.Haskell.TH.Syntax hiding (Type)
 import Splices (eqTH)
 
 test_reify_type_cusks, test_reify_type_no_cusks :: [Bool]
 (test_reify_type_cusks, test_reify_type_no_cusks) =
   $(do cusk_decls <-
-         [d| data A1 (a :: *)
-             type A2 (a :: *) = (a :: *)
+         [d| data A1 (a :: Type)
+             type A2 (a :: Type) = (a :: Type)
              type family A3 a
              data family A4 a
-             type family A5 (a :: *) :: * where
+             type family A5 (a :: Type) :: Type where
                A5 a = a
-             class A6 (a :: *) where
+             class A6 (a :: Type) where
                type A7 a b
 
-             data A8 (a :: k) :: k -> *
+             data A8 (a :: k) :: k -> Type
 #if __GLASGOW_HASKELL__ >= 804
-             data A9 (a :: j) :: forall k. k -> *
+             data A9 (a :: j) :: forall k. k -> Type
 #endif
 #if __GLASGOW_HASKELL__ >= 809
              data A10 (k :: Type) (a :: k)
-             data A11 :: forall k -> k -> *
+             data A11 :: forall k -> k -> Type
 #endif
            |]
 
        no_cusk_decls <-
          [d| data B1 a
-             type B2 (a :: *) = a
-             type B3 a = (a :: *)
-             type family B4 (a :: *) where
+             type B2 (a :: Type) = a
+             type B3 a = (a :: Type)
+             type family B4 (a :: Type) where
                B4 a = a
-             type family B5 a :: * where
+             type family B5 a :: Type where
                B5 a = a
              class B6 a where
-               type B7 (a :: *) (b :: *) :: *
+               type B7 (a :: Type) (b :: Type) :: Type
 
-             data B8 :: k -> *
+             data B8 :: k -> Type
 #if __GLASGOW_HASKELL__ >= 804
-             data B9 :: forall j. j -> k -> *
+             data B9 :: forall j. j -> k -> Type
 #endif
            |]
 

--- a/Test/ReifyTypeSigs.hs
+++ b/Test/ReifyTypeSigs.hs
@@ -11,9 +11,6 @@ module ReifyTypeSigs where
 import Data.Kind
 import Data.Proxy
 #endif
-#if __GLASGOW_HASKELL__ < 710
-import Data.Traversable (traverse)
-#endif
 import Language.Haskell.TH.Desugar
 import Language.Haskell.TH.Syntax hiding (Type)
 import Splices (eqTH)

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -11,10 +11,10 @@ rae@cs.brynmawr.edu
              ScopedTypeVariables, GADTs, ViewPatterns, TupleSections,
              TypeOperators, PartialTypeSignatures, PatternSynonyms,
              TypeApplications #-}
-{-# OPTIONS -fno-warn-incomplete-patterns -fno-warn-overlapping-patterns
-            -fno-warn-unused-matches -fno-warn-type-defaults
-            -fno-warn-missing-signatures -fno-warn-unused-do-bind
-            -fno-warn-missing-fields -fno-warn-incomplete-record-updates
+{-# OPTIONS -Wno-incomplete-patterns -Wno-overlapping-patterns
+            -Wno-unused-matches -Wno-type-defaults
+            -Wno-missing-signatures -Wno-unused-do-bind
+            -Wno-missing-fields -Wno-incomplete-record-updates
             -Wno-partial-type-signatures -Wno-redundant-constraints #-}
 
 #if __GLASGOW_HASKELL__ >= 805

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -45,8 +45,8 @@ rae@cs.brynmawr.edu
 {-# LANGUAGE OverloadedRecordDot #-}
 #endif
 
-{-# OPTIONS_GHC -fno-warn-missing-signatures -fno-warn-type-defaults
-                -fno-warn-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-missing-signatures -Wno-type-defaults
+                -Wno-name-shadowing #-}
 
 module Splices where
 

--- a/Test/T159Decs.hs
+++ b/Test/T159Decs.hs
@@ -1,5 +1,5 @@
-{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
-{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 
 -- | Defines two non-exhaustive functions that roundtrip through desugaring
 -- and sweetening. Both of these functions should desugar to definitions that

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -1,5 +1,5 @@
 name:           th-desugar
-version:        1.13
+version:        1.14
 cabal-version:  >= 1.10
 synopsis:       Functions to desugar Template Haskell
 homepage:       https://github.com/goldfirere/th-desugar
@@ -12,9 +12,7 @@ extra-source-files: README.md, CHANGES.md
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-tested-with:    GHC == 7.8.4
-              , GHC == 7.10.3
-              , GHC == 8.0.2
+tested-with:    GHC == 8.0.2
               , GHC == 8.2.2
               , GHC == 8.4.4
               , GHC == 8.6.5
@@ -45,9 +43,9 @@ source-repository head
 
 library
   build-depends:
-      base >= 4.7 && < 5,
+      base >= 4.9 && < 5,
       ghc-prim,
-      template-haskell >= 2.9 && < 2.19,
+      template-haskell >= 2.11 && < 2.19,
       containers >= 0.5,
       mtl >= 2.1,
       ordered-containers >= 0.2.2,
@@ -56,9 +54,6 @@ library
       th-lift >= 0.6.1,
       th-orphans >= 0.13.7,
       transformers-compat >= 0.6.3
-  if !impl(ghc >= 8.0)
-      build-depends: fail == 4.9.*,
-                     semigroups >= 0.16
   default-extensions: TemplateHaskell
   exposed-modules:    Language.Haskell.TH.Desugar
                       Language.Haskell.TH.Desugar.Expand

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -76,8 +76,6 @@ library
 test-suite spec
   type:               exitcode-stdio-1.0
   ghc-options:        -Wall
-  if impl(ghc >= 8.6)
-    ghc-options:      -Wno-star-is-type
   default-language:   Haskell2010
   default-extensions: TemplateHaskell
   hs-source-dirs:     Test


### PR DESCRIPTION
This requires GHC 8.0 as the minimum, removing support for GHC 7.8 and 7.10 in the process. As a consequence, we can now remove enormous chunks of unneeded CPP.

Now that we no longer use `template-haskell`'s `Strict` type, the `strictToBang` function no longer serves a useful purpose. I've opted to remove it, which makes this commit a breaking change (albeit a pretty obscure one).

While I was in town, I spruced up the code in various places to make use of more modern GHC features that previously weren't avaiable on all supported versions:

* We no longer need to explicitly derive `Typeable` instances, as GHC now does this automatically for all data types.
* We no longer need to bluntly disable `-Wstar-is-type`, as we can simply import `Data.Kind` unconditionally now.
* We now favor `-W`-style warnings over `-fwarn-`style ones, the former being the modern warning syntax in GHC.
* We now use `TypeApplications` to simplify some boilerplate in the `OMap` and `OSet` implementations.
* We now favor the `TemplateHaskellQuotes` extension over `TemplateHaskell`, as we do not need the full power of `TemplateHaskell` in most places.