### PR TITLE
Desugar lambdas and guards with unboxed tuples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@ Version 1.14 [????.??.??]
 -------------------------
 * Drop support for GHC 7.8 and 7.10. As a consequence of this, the
   `strictToBang` was removed as it no longer serves a useful purpose.
+* Desugared lambda expressions and guards that bind multiple patterns can now
+  have patterns with unlifted types. The desugared code uses `UnboxedTuples` to
+  make this possible, so if you load the desugared code into GHCi on prior to
+  GHC 9.2, you will need to enable `-fobject-code`.
 * Fix an inconsistency which caused non-exhaustive `case` expressions to be
   desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
   desugared into code that throws a "`Non-exhaustive patterns in...`" error at

--- a/Test/T158Exp.hs
+++ b/Test/T158Exp.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | A regression test for #158 which ensures that lambda expressions
+-- containing patterns with unlifted types desugar as expected. We define this
+-- test in its own module, without UnboxedTuples enabled, to ensure that users
+-- do not have to enable the extension themselves.
+module T158Exp where
+
+import Language.Haskell.TH.Desugar
+
+t158 :: ()
+t158 =
+  $([| (\27# 42# -> ()) 27# 42# |] >>= dsExp >>= return . expToTH)

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -85,6 +85,7 @@ test-suite spec
                       ReifyTypeCUSKs
                       ReifyTypeSigs
                       Splices
+                      T158Exp
                       T159Decs
 
   build-depends:


### PR DESCRIPTION
Previously, we would desugar lambda expressions and guards by grouping up bound variables into auxiliary tuples that would be `case`d on. Using lifted tuples meant that this approach would not work for unlifted types, however. This patch changes the desugaring to use unboxed tuples instead, which does not have such restrictions. Miraculously, we can even do so without requiring users to enable `UnboxedTuples`! See `Note [Auxiliary tuples in pattern matching]` in `L.H.TH.Desugar.Core`.

Fixes #158.