### PR TITLE
Support TH constructs added in GHC 9.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,19 @@
 
 Version 1.14 [????.??.??]
 -------------------------
+* Support GHC 9.4.
 * Drop support for GHC 7.8 and 7.10. As a consequence of this, the
   `strictToBang` was removed as it no longer serves a useful purpose.
 * Desugared lambda expressions and guards that bind multiple patterns can now
   have patterns with unlifted types. The desugared code uses `UnboxedTuples` to
   make this possible, so if you load the desugared code into GHCi on prior to
   GHC 9.2, you will need to enable `-fobject-code`.
+* `th-desugar` now desugars `PromotedInfixT` and `PromotedUInfixT`, which were
+  added in GHC 9.4. Mirroring the existing treatment of other `Promoted*`
+  `Type`s, `PromotedInfixT` is desugared to an application of a `DConT` applied
+  to two arguments, just like `InfixT` is desugared. Similarly, attempting to
+  desugar a `PromotedUInfixT` results in an error, just like attempting to
+  desugar a `UInfixT` would be.
 * Fix an inconsistency which caused non-exhaustive `case` expressions to be
   desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
   desugared into code that throws a "`Non-exhaustive patterns in...`" error at

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ Version 1.14 [????.??.??]
   desugar a `UInfixT` would be.
 * `th-desugar` now supports `DefaultD` (i.e., `default` declarations) and
   `OpaqueP` (i.e., `OPAQUE` pragmas), which were added in GHC 9.4.
+* `th-desugar` now desugars `LamCasesE` (i.e., `\cases` expressions), which was
+  added in GHC 9.4. A `\cases` expression is desugared to an ordinary lambda
+  expression, much like `\case` is currently desugared.
 * Fix an inconsistency which caused non-exhaustive `case` expressions to be
   desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
   desugared into code that throws a "`Non-exhaustive patterns in...`" error at

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,8 @@ Version 1.14 [????.??.??]
   to two arguments, just like `InfixT` is desugared. Similarly, attempting to
   desugar a `PromotedUInfixT` results in an error, just like attempting to
   desugar a `UInfixT` would be.
-* `th-desugar` now supports `DefaultD` (i.e., `default` declarations).
+* `th-desugar` now supports `DefaultD` (i.e., `default` declarations) and
+  `OpaqueP` (i.e., `OPAQUE` pragmas), which were added in GHC 9.4.
 * Fix an inconsistency which caused non-exhaustive `case` expressions to be
   desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
   desugared into code that throws a "`Non-exhaustive patterns in...`" error at

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Version 1.14 [????.??.??]
   to two arguments, just like `InfixT` is desugared. Similarly, attempting to
   desugar a `PromotedUInfixT` results in an error, just like attempting to
   desugar a `UInfixT` would be.
+* `th-desugar` now supports `DefaultD` (i.e., `default` declarations).
 * Fix an inconsistency which caused non-exhaustive `case` expressions to be
   desugared into uses of `EmptyCase`. Non-exhaustive `case` expressions are now
   desugared into code that throws a "`Non-exhaustive patterns in...`" error at

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -255,6 +255,7 @@ data DPragma = DInlineP Name Inline RuleMatch Phases
              | DAnnP AnnTarget DExp
              | DLineP Int String
              | DCompleteP [Name] (Maybe Name)
+             | DOpaqueP Name
              deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's @RuleBndr@ type.

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -135,6 +135,7 @@ data DDec = DLetDec DLetDec
           | DKiSigD Name DKind
               -- DKiSigD is part of DDec, not DLetDec, because standalone kind
               -- signatures can only appear on the top level.
+          | DDefaultD [DType]
           deriving (Eq, Show, Data, Generic)
 
 -- | Corresponds to TH's 'PatSynDir' type

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -1014,6 +1014,9 @@ dsPragma (LineP n str)                   = return $ DLineP n str
 #if __GLASGOW_HASKELL__ >= 801
 dsPragma (CompleteP cls mty)             = return $ DCompleteP cls mty
 #endif
+#if __GLASGOW_HASKELL__ >= 903
+dsPragma (OpaqueP n)                     = return $ DOpaqueP n
+#endif
 
 -- | Desugar a @RuleBndr@.
 dsRuleBndr :: DsMonad q => RuleBndr -> q DRuleBndr

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -737,6 +737,9 @@ dsDec (ImplicitParamBindD {}) = impossible "Non-`let`-bound implicit param bindi
 #if __GLASGOW_HASKELL__ >= 809
 dsDec (KiSigD n ki) = (:[]) <$> (DKiSigD n <$> dsType ki)
 #endif
+#if __GLASGOW_HASKELL__ >= 903
+dsDec (DefaultD tys) = (:[]) <$> (DDefaultD <$> mapM dsType tys)
+#endif
 
 -- | Desugar a 'DataD' or 'NewtypeD'.
 dsDataDec :: DsMonad q

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -140,6 +140,12 @@ decToTH (DKiSigD n ki) = KiSigD n (typeToTH ki)
 decToTH (DKiSigD {})   =
   error "Standalone kind signatures supported only in GHC 8.10+"
 #endif
+#if __GLASGOW_HASKELL__ >= 903
+decToTH (DDefaultD tys) = DefaultD (map typeToTH tys)
+#else
+decToTH (DDefaultD{})   =
+  error "Default declarations supported only in GHC 9.4+"
+#endif
 
 #if __GLASGOW_HASKELL__ < 801
 patSynErr :: a

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -250,6 +250,11 @@ pragmaToTH (DCompleteP {}) = error "COMPLETE pragmas only supported in GHC 8.2+"
 #else
 pragmaToTH (DCompleteP cls mty) = CompleteP cls mty
 #endif
+#if __GLASGOW_HASKELL__ >= 903
+pragmaToTH (DOpaqueP n) = OpaqueP n
+#else
+pragmaToTH (DOpaqueP {}) = error "OPAQUE pragmas only supported in GHC 9.4+"
+#endif
 
 ruleBndrToTH :: DRuleBndr -> RuleBndr
 ruleBndrToTH (DRuleVar n) = RuleVar n

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -149,6 +149,7 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
 #endif
 #if __GLASGOW_HASKELL__ >= 903
              , "opaque_pragma" ~: $test55_opaque_pragma @=? $(dsSplice test55_opaque_pragma)
+             , "lambda_cases" ~: $test56_lambda_cases @=? $(dsSplice test56_lambda_cases)
 #endif
              ]
 

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -147,6 +147,9 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
 #if __GLASGOW_HASKELL__ >= 902
              , "overloaded_record_dot" ~: $test54_overloaded_record_dot @=? $(dsSplice test54_overloaded_record_dot)
 #endif
+#if __GLASGOW_HASKELL__ >= 903
+             , "opaque_pragma" ~: $test55_opaque_pragma @=? $(dsSplice test55_opaque_pragma)
+#endif
              ]
 
 test35a = $test35_expand

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -345,6 +345,10 @@ test55_opaque_pragma =
          f x = x
          {-# OPAQUE f #-}
      in f "Hello, World!" |]
+
+test56_lambda_cases =
+  [| (\cases (Just x) (Just y) -> x ++ y
+             _        _        -> "") (Just "Hello") (Just "World") |]
 #endif
 
 type family TFExpand x
@@ -769,5 +773,6 @@ test_exprs = [ test1_sections
 #endif
 #if __GLASGOW_HASKELL__ >= 903
              , test55_opaque_pragma
+             , test56_lambda_cases
 #endif
              ]

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -339,6 +339,14 @@ test54_overloaded_record_dot =
      in (ord2.unORD2.unORD1, (.unORD2.unORD1) ord2) |]
 #endif
 
+#if __GLASGOW_HASKELL__ >= 903
+test55_opaque_pragma =
+  [| let f :: String -> String
+         f x = x
+         {-# OPAQUE f #-}
+     in f "Hello, World!" |]
+#endif
+
 type family TFExpand x
 type instance TFExpand Int = Bool
 type instance TFExpand (Maybe a) = [a]
@@ -758,5 +766,8 @@ test_exprs = [ test1_sections
 #endif
 #if __GLASGOW_HASKELL__ >= 902
              , test54_overloaded_record_dot
+#endif
+#if __GLASGOW_HASKELL__ >= 903
+             , test55_opaque_pragma
 #endif
              ]


### PR DESCRIPTION
This adds support for the following TH constructs, newly introduced in GHC 9.4:

* `PromotedInfixT` and `PromotedUInfixT`. These are desugared very similarly to `InfixT` and `UInfixT`.
* `DefaultD` (`default` declarations).
* `OpaqueP` (`OPAQUE` pragmas).
* `LamCasesE` (`\cases` expressions). These are desugared to ordinary lambda expressions, similarly to how `LamCaseE` is desugared.

For more details, refer to the individual commit messages.

This addresses four check boxes in #157.