### PR TITLE
Local reification for pattern synonym record selectors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 `th-desugar` release notes
 ==========================
 
+next [????.??.??]
+-----------------
+* Local reification can now reify the types of pattern synonym record
+  selectors.
+
 Version 1.14 [2022.08.23]
 -------------------------
 * Support GHC 9.4.


### PR DESCRIPTION
This augments `th-desugar`'s local reification machinery with the power to reconstruct the types of pattern synonym record selectors. See the Haddocks on the new `maybeReifyPatSynRecSelector` function for a description of how this works.

Fixes #137.