### PR TITLE
Make local reification aware of GADT type variable binder ordering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ next [????.??.??]
 -----------------
 * Local reification can now reify the types of pattern synonym record
   selectors.
+* Fix a bug in which the types of locally reified GADT record selectors would
+  sometimes have type variables quantified in the wrong order.
 
 Version 1.14 [2022.08.23]
 -------------------------


### PR DESCRIPTION
This is implemented by remembering the explicit `forall` in a GADT constructor's type signature (if one exists) in `RecSelGADT` and using it later to construct the record selector's type signature.

Fixes #171.