### PR TITLE
`getDataD`: Also return a `DataFlavor`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,12 @@ Version 1.15 [????.??.??]
     `Bang NoSourceUnpackedness NoSourceStrictness`.
   * A `DDataInstD` can have a `DataFlavor` of `NewType` or `Data`, but not
     `TypeData`.
+* The type of `getDataD` has been changed to also include a `DataFlavor`:
+
+  ```diff
+  -getDataD :: DsMonad q => String -> Name -> q ([TyVarBndrUnit], [Con])
+  +getDataD :: DsMonad q => String -> Name -> q (DataFlavor, [TyVarBndrUnit], [Con])
+  ```
 * Local reification can now reify the types of pattern synonym record
   selectors.
 * Fix a bug in which the types of locally reified GADT record selectors would

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -19,6 +19,8 @@ import Language.Haskell.TH.Syntax (Lift)
 import Language.Haskell.TH.Datatype.TyVarBndr (Specificity(..))
 #endif
 
+import Language.Haskell.TH.Desugar.Util (DataFlavor)
+
 -- | Corresponds to TH's @Exp@ type. Note that @DLamE@ takes names, not patterns.
 data DExp = DVarE Name
           | DConE Name
@@ -104,14 +106,6 @@ data DLetDec = DFunD Name [DClause]
              | DInfixD Fixity Name
              | DPragmaD DPragma
              deriving (Eq, Show, Data, Generic, Lift)
-
--- | Is a data type or data instance declaration a @newtype@ declaration, a
--- @data@ declaration, or a @type data@ declaration?
-data DataFlavor
-  = Newtype  -- ^ @newtype@
-  | Data     -- ^ @data@
-  | TypeData -- ^ @type data@
-  deriving (Eq, Show, Data, Generic, Lift)
 
 -- | Corresponds to TH's @Dec@ type.
 data DDec = DLetDec DLetDec

--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -173,7 +173,7 @@ dsExp (RecUpdE exp field_exps) = do
                     VarI _name ty _m_dec -> extract_first_arg ty
                     _ -> impossible "Record update with an invalid field name."
   type_name <- extract_type_name applied_type
-  (_, cons) <- getDataD "This seems to be an error in GHC." type_name
+  (_, _, cons) <- getDataD "This seems to be an error in GHC." type_name
   let filtered_cons = filter_cons_with_names cons (map fst field_exps)
   exp' <- dsExp exp
   matches <- mapM con_to_dmatch filtered_cons
@@ -1497,7 +1497,7 @@ isUniversalPattern (DLitP {}) = return False
 isUniversalPattern (DVarP {}) = return True
 isUniversalPattern (DConP con_name _ pats) = do
   data_name <- dataConNameToDataName con_name
-  (_tvbs, cons) <- getDataD "Internal error." data_name
+  (_df, _tvbs, cons) <- getDataD "Internal error." data_name
   if length cons == 1
   then fmap and $ mapM isUniversalPattern pats
   else return False

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -6,9 +6,9 @@ rae@cs.brynmawr.edu
 Utility functions for th-desugar package.
 -}
 
-{-# LANGUAGE CPP, DeriveDataTypeable, RankNTypes, ScopedTypeVariables,
-             TupleSections, AllowAmbiguousTypes, TemplateHaskellQuotes,
-             TypeApplications #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveGeneric, DeriveLift, RankNTypes,
+             ScopedTypeVariables, TupleSections, AllowAmbiguousTypes,
+             TemplateHaskellQuotes, TypeApplications #-}
 
 module Language.Haskell.TH.Desugar.Util (
   newUniqueName,
@@ -29,7 +29,8 @@ module Language.Haskell.TH.Desugar.Util (
   unSigType, unfoldType, ForallTelescope(..), FunArgs(..), VisFunArg(..),
   filterVisFunArgs, ravelType, unravelType,
   TypeArg(..), applyType, filterTANormals, probablyWrongUnTypeArg,
-  bindIP
+  bindIP,
+  DataFlavor(..)
   ) where
 
 import Prelude hiding (mapM, foldl, concatMap, any)
@@ -43,10 +44,11 @@ import Language.Haskell.TH.Syntax
 import qualified Control.Monad.Fail as Fail
 import Data.Foldable
 import qualified Data.Kind as Kind
-import Data.Generics hiding ( Fixity )
+import Data.Generics ( Data, Typeable, everything, extM, gmapM, mkQ )
 import Data.Traversable
 import Data.Maybe
 import GHC.Classes ( IP )
+import GHC.Generics ( Generic )
 import Unsafe.Coerce ( unsafeCoerce )
 
 ----------------------------------------
@@ -535,3 +537,11 @@ starKindName = ''(Kind.*)
 uniStarKindName :: Name
 uniStarKindName = ''(Kind.★)
 #endif
+
+-- | Is a data type or data instance declaration a @newtype@ declaration, a
+-- @data@ declaration, or a @type data@ declaration?
+data DataFlavor
+  = Newtype  -- ^ @newtype@
+  | Data     -- ^ @data@
+  | TypeData -- ^ @type data@
+  deriving (Eq, Show, Data, Generic, Lift)

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -329,10 +329,11 @@ test_getDataD_kind_sig =
             let type_kind     = DConT typeKindName
                 data_kind_sig = DArrowT `DAppT` type_kind `DAppT`
                                   (DArrowT `DAppT` type_kind `DAppT` type_kind)
-            (tvbs, _) <- withLocalDeclarations
-                           [decToTH (DDataD Data [] data_name [DPlainTV a ()]
-                                            (Just data_kind_sig) [] [])]
-                           (getDataD "th-desugar: Impossible" data_name)
+            (_, tvbs, _) <-
+              withLocalDeclarations
+                [decToTH (DDataD Data [] data_name [DPlainTV a ()]
+                                 (Just data_kind_sig) [] [])]
+                (getDataD "th-desugar: Impossible" data_name)
             [| $(Syn.lift (length tvbs)) |])
 
 test_t100 :: Bool


### PR DESCRIPTION
This requires moving the definition of `DataFlavor` to `L.H.TH.Desugar.Util` in order to avoid import cycles.

This is ultimately motivated by an eventual fix for goldfirere/singletons#559. While this is a breaking API change, `singletons` is the only user of `getDataD` that I am aware of.