### PR TITLE
Handle `InfixT`/`PromotedInfixT` in `unfoldType` properly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 `th-desugar` release notes
 ==========================
 
+Version next [????.??.??]
+-------------------------
+* Fix a bug in which infix data family declaration would mistakenly be rejected
+  when reified locally.
+
 Version 1.15 [2023.03.12]
 -------------------------
 * Support GHC 9.6.

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -314,14 +314,14 @@ unfoldType :: Type -> (Type, [TypeArg])
 unfoldType = go []
   where
     go :: [TypeArg] -> Type -> (Type, [TypeArg])
-    go acc (ForallT _ _ ty) = go acc ty
-    go acc (AppT ty1 ty2)   = go (TANormal ty2:acc) ty1
-    go acc (SigT ty _)      = go acc ty
-    go acc (ParensT ty)     = go acc ty
+    go acc (ForallT _ _ ty)           = go acc ty
+    go acc (AppT ty1 ty2)             = go (TANormal ty2:acc) ty1
+    go acc (SigT ty _)                = go acc ty
+    go acc (ParensT ty)               = go acc ty
 #if __GLASGOW_HASKELL__ >= 807
-    go acc (AppKindT ty ki) = go (TyArg ki:acc) ty
+    go acc (AppKindT ty ki)           = go (TyArg ki:acc) ty
 #endif
-    go acc ty               = (ty, acc)
+    go acc ty                         = (ty, acc)
 
 -- | An argument to a type, either a normal type ('TANormal') or a visible
 -- kind application ('TyArg').

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -830,8 +830,8 @@ main = hspec $ do
                mapM (\ t -> withLocalDeclarations [] (dsType t >>= expandType >>= return . typeToTH)) >>=
               Syn.lift . map pprint)
 
-    zipWith3M (\a b n -> it ("reifies local definition " ++ show n) $ a == b)
-      local_reifications normal_reifications [1..]
+    zipWith3M (\a b nm -> it ("reifies local definition " ++ nameBase nm) $ a == b)
+      local_reifications normal_reifications reifyDecsNames
 
     zipWithM (\b n -> it ("works on simplCase test " ++ show n) b) simplCase [1..]
 

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -672,6 +672,10 @@ reifyDecs = [d|
   type data R38 a where
     R39 :: forall a. a -> R38 a
 #endif
+
+  -- A regression test for #184
+  data family x ^^^ y
+  data instance x ^^^ y = R40 x y
   |]
 
 reifyDecsNames :: [Name]
@@ -690,6 +694,7 @@ reifyDecsNames = map mkName
 #if __GLASGOW_HASKELL__ >= 906
   , "R36", "R37", "R38", "R39"
 #endif
+  , "R40"
   ]
 
 simplCaseTests :: [Q Exp]


### PR DESCRIPTION
This adds two missing cases for `InfixT` and `PromotedUInfixT` in `unfoldType`. Missing a case for the former can cause data family declarations to be spuriously rejected, as noted in https://github.com/goldfirere/th-desugar/issues/184, so I have added a regression test for this.

Fixes https://github.com/goldfirere/th-desugar/issues/184.