### PR TITLE
Define `toposortKindVarsOfTvbs`, use it to fix #188

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Version next [????.??.??]
 -------------------------
 * Fix a bug in which infix data family declaration would mistakenly be rejected
   when reified locally.
+* Fix a bug in which data types that use visible dependent quantification would
+  produce ill-scoped code when desugared.
 
 Version 1.15 [2023.03.12]
 -------------------------

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -96,7 +96,8 @@ module Language.Haskell.TH.Desugar (
   unboxedSumDegree_maybe, unboxedSumNameDegree_maybe,
   unboxedTupleDegree_maybe, unboxedTupleNameDegree_maybe,
   isTypeKindName, typeKindName, bindIP,
-  mkExtraDKindBinders, dTyVarBndrToDType, changeDTVFlags, toposortTyVarsOf,
+  mkExtraDKindBinders, dTyVarBndrToDType, changeDTVFlags,
+  toposortTyVarsOf, toposortKindVarsOfTvbs,
 
   -- ** 'FunArgs' and 'VisFunArg'
   FunArgs(..), ForallTelescope(..), VisFunArg(..),

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -29,6 +29,10 @@ rae@cs.brynmawr.edu
 {-# LANGUAGE QuantifiedConstraints #-}
 #endif
 
+#if __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+
 #if __GLASGOW_HASKELL__ >= 807
 {-# LANGUAGE ImplicitParams #-}
 #endif
@@ -676,6 +680,9 @@ reifyDecs = [d|
   -- A regression test for #184
   data family x ^^^ y
   data instance x ^^^ y = R40 x y
+
+  -- A regression test for #188
+  data R41 a (x :: Maybe a) = R42
   |]
 
 reifyDecsNames :: [Name]
@@ -695,6 +702,7 @@ reifyDecsNames = map mkName
   , "R36", "R37", "R38", "R39"
 #endif
   , "R40"
+  , "R41", "R42"
   ]
 
 simplCaseTests :: [Q Exp]


### PR DESCRIPTION
`toposortKindVarsOfTvbs` ensures that type variables bound earlier in a telescope do not get returned as free variables, thereby fixing the issue observed in #188.