### PR TITLE
Support invisible binders in type-level declarations

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.6
+# version: 0.17.20230826
 #
-# REGENDATA ("0.16.6",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.17.20230826",["--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,14 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.8.0.20230822
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.8.0.20230822
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.6.2
+            compilerKind: ghc
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.4.7
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.7
@@ -86,8 +91,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -95,8 +101,9 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
@@ -111,10 +118,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -128,7 +137,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -157,6 +166,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -208,6 +229,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(th-desugar)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16
+# version: 0.16.6
 #
-# REGENDATA ("0.16",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.16.6",["--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,38 @@
 
 Version 1.16 [????.??.??]
 -------------------------
+* Support GHC 9.8.
+* Require `th-abstraction-0.6` or later.
+* Add support for invisible binders in type-level declarations. As part of this
+  change:
+
+  * `Language.Haskell.TH.Desugar` now exports a `DTyVarBndrVis` type synonym,
+    which is the `th-desugar` counterpart to `TyVarBndrVis`. It also exports a
+    `dsTvbVis` function, which is the `DTyVarBndrVis` counterpart to `dsTvbSpec`
+    and `dsTvbUnit`.
+  * `Language.Haskell.TH.Desugar` now re-exports `BndrVis` from
+    `template-haskell`.
+  * The `DDataD`, `DTySynD`, `DClassD`, `DDataFamilyD`, and `DTypeFamilyHead`
+    parts of the `th-desugar` AST now use `DTyVarBndrVis` instead of
+    `DTyVarBndrUnit`.
+  * The `mkExtraDKindBinders`, `dsCon`, and `dsDataDec` functions now use
+    `DTyVarBndrVis` instead of `DTyVarBndrUnit`.
+  * The `getDataD` function now uses `TyVarBndrVis` instead of `TyVarBndrUnit`.
+
+  It is possible that you will need to convert between `TyVarBndrUnit` and
+  `TyVarBndrVis` to adapt your existing `th-desugar` code. (Note that `TyVarBndr
+  flag` is an instance of `Functor`, so this can be accomplished with `fmap`.)
+* `Language.Haskell.TH.Desugar` now exports a family of functions for converting
+  type variable binders into type arguments while preserving their visibility:
+
+  * The `tyVarBndrVisToTypeArg` and `tyVarBndrVisToTypeArgWithSig` functions
+    convert a `TyVarBndrVis` to a `TypeArg`. `tyVarBndrVisToTypeArg` omits kind
+    signatures when converting `KindedTV`s, while `tyVarBndrVisToTypeArgWithSig`
+    preserves kind signatures.
+  * The `dTyVarBndrVisToDTypeArg` and `dTyVarBndrVisToDTypeArgWithSig` functions
+    convert a `DTyVarBndrVis` to a `DTypeArg`. `dTyVarBndrVisToDTypeArg` omits
+    kind signatures when converting `DKindedTV`s, while
+    `dTyVarBndrVisToDTypeArgWithSig` preserves kind signatures.
 * The `tupleNameDegree_maybe` function now returns:
   * `Just 0` when the argument is `''Unit`
   * `Just 1` when the argument is `''Solo` or `'MkSolo`

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -18,6 +18,9 @@ import Language.Haskell.TH.Syntax (Lift)
 #if __GLASGOW_HASKELL__ < 900
 import Language.Haskell.TH.Datatype.TyVarBndr (Specificity(..))
 #endif
+#if __GLASGOW_HASKELL__ < 907
+import Language.Haskell.TH.Datatype.TyVarBndr (BndrVis)
+#endif
 
 import Language.Haskell.TH.Desugar.Util (DataFlavor)
 
@@ -91,6 +94,9 @@ type DTyVarBndrSpec = DTyVarBndr Specificity
 -- | Corresponds to TH's @TyVarBndrUnit@
 type DTyVarBndrUnit = DTyVarBndr ()
 
+-- | Corresponds to TH's @TyVarBndrVis@
+type DTyVarBndrVis = DTyVarBndr BndrVis
+
 -- | Corresponds to TH's @Match@ type.
 data DMatch = DMatch DPat DExp
   deriving (Eq, Show, Data, Generic, Lift)
@@ -120,9 +126,9 @@ data DDec = DLetDec DLetDec
             --   'DDerivClause's, the 'DCxt' will be empty, and the 'DConFields'
             --   in each 'DCon' will be a 'NormalC' where each 'Bang' is equal
             --   to @Bang 'NoSourceUnpackedness' 'NoSourceStrictness'@.
-          | DDataD DataFlavor DCxt Name [DTyVarBndrUnit] (Maybe DKind) [DCon] [DDerivClause]
-          | DTySynD Name [DTyVarBndrUnit] DType
-          | DClassD DCxt Name [DTyVarBndrUnit] [FunDep] [DDec]
+          | DDataD DataFlavor DCxt Name [DTyVarBndrVis] (Maybe DKind) [DCon] [DDerivClause]
+          | DTySynD Name [DTyVarBndrVis] DType
+          | DClassD DCxt Name [DTyVarBndrVis] [FunDep] [DDec]
             -- | Note that the @Maybe [DTyVarBndrUnit]@ field is dropped
             -- entirely when sweetened, so it is only useful for functions
             -- that directly consume @DDec@s.
@@ -130,7 +136,7 @@ data DDec = DLetDec DLetDec
           | DForeignD DForeign
           | DOpenTypeFamilyD DTypeFamilyHead
           | DClosedTypeFamilyD DTypeFamilyHead [DTySynEqn]
-          | DDataFamilyD Name [DTyVarBndrUnit] (Maybe DKind)
+          | DDataFamilyD Name [DTyVarBndrVis] (Maybe DKind)
             -- | A data family instance declaration. Note that desugaring
             -- upholds the following properties regarding the 'DataFlavor'
             -- field:
@@ -176,7 +182,7 @@ data PatSynArgs
 #endif
 
 -- | Corresponds to TH's 'TypeFamilyHead' type
-data DTypeFamilyHead = DTypeFamilyHead Name [DTyVarBndrUnit] DFamilyResultSig
+data DTypeFamilyHead = DTypeFamilyHead Name [DTyVarBndrVis] DFamilyResultSig
                                        (Maybe InjectivityAnn)
                      deriving (Eq, Show, Data, Generic, Lift)
 

--- a/Test/Dec.hs
+++ b/Test/Dec.hs
@@ -9,6 +9,12 @@ rae@cs.brynmawr.edu
              FlexibleInstances, DataKinds, CPP, RankNTypes,
              StandaloneDeriving, DefaultSignatures,
              ConstraintKinds, RoleAnnotations, DeriveAnyClass #-}
+#if __GLASGOW_HASKELL__ >= 810
+{-# LANGUAGE StandaloneKindSignatures #-}
+#endif
+#if __GLASGOW_HASKELL__ >= 907
+{-# LANGUAGE TypeAbstractions #-}
+#endif
 
 {-# OPTIONS_GHC -Wno-orphans -Wno-name-shadowing
                 -Wno-redundant-constraints #-}
@@ -42,6 +48,10 @@ $(S.dectest17)
 
 #if __GLASGOW_HASKELL__ >= 809
 $(S.dectest18)
+#endif
+
+#if __GLASGOW_HASKELL__ >= 907
+$(S.dectest19)
 #endif
 
 $(fmap unqualify S.instance_test)

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -49,6 +49,7 @@ import Dec ( RecordSel )
 import ReifyTypeCUSKs
 import ReifyTypeSigs
 import T159Decs ( t159A, t159B )
+import qualified Language.Haskell.TH.Datatype.TyVarBndr as THAbs
 import Language.Haskell.TH.Desugar
 import qualified Language.Haskell.TH.Desugar.OSet as OS
 import Language.Haskell.TH.Desugar.Expand  ( expandUnsoundly )
@@ -291,7 +292,7 @@ test_stuck_tyfam_expansion =
                    (decsToTH [ -- type family F (x :: k) :: k
                                DOpenTypeFamilyD
                                  (DTypeFamilyHead fam_name
-                                                  [DKindedTV x () (DVarT k)]
+                                                  [DKindedTV x THAbs.BndrReq (DVarT k)]
                                                   (DKindSig (DVarT k))
                                                   Nothing)
                                -- type instance F (x :: ()) = x
@@ -346,7 +347,7 @@ test_getDataD_kind_sig =
                                   (DArrowT `DAppT` type_kind `DAppT` type_kind)
             (_, tvbs, _) <-
               withLocalDeclarations
-                [decToTH (DDataD Data [] data_name [DPlainTV a ()]
+                [decToTH (DDataD Data [] data_name [DPlainTV a THAbs.BndrReq]
                                  (Just data_kind_sig) [] [])]
                 (getDataD "th-desugar: Impossible" data_name)
             [| $(Syn.lift (length tvbs)) |])
@@ -425,7 +426,7 @@ test_t132 =
            --     m :: a
            --
            -- We define this by hand to avoid GHC#17608 on pre-9.0 GHCs.
-           decs = sweeten [ DClassD [] c [DPlainTV a ()] []
+           decs = sweeten [ DClassD [] c [DPlainTV a THAbs.BndrReq] []
                             [ DLetDec (DInfixD fixity m)
                             , DLetDec (DSigD m (DVarT a))
                             ]
@@ -589,7 +590,7 @@ test_t171 =
                    Data
                    []
                    t
-                   [DPlainTV x (), DPlainTV y ()]
+                   [DPlainTV x THAbs.BndrReq, DPlainTV y THAbs.BndrReq]
                    Nothing
                    [ DCon
                        [bTvb, aTvb, cTvb]

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -20,8 +20,9 @@ tested-with:    GHC == 8.0.2
               , GHC == 8.10.7
               , GHC == 9.0.2
               , GHC == 9.2.7
-              , GHC == 9.4.4
-              , GHC == 9.6.1
+              , GHC == 9.4.7
+              , GHC == 9.6.2
+              , GHC == 9.8.1
 description:
     This package provides the Language.Haskell.TH.Desugar module, which desugars
     Template Haskell's rich encoding of Haskell syntax into a simpler encoding.

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -47,12 +47,12 @@ library
   build-depends:
       base >= 4.9 && < 5,
       ghc-prim,
-      template-haskell >= 2.11 && < 2.21,
+      template-haskell >= 2.11 && < 2.22,
       containers >= 0.5,
       mtl >= 2.1 && < 2.4,
       ordered-containers >= 0.2.2,
       syb >= 0.4,
-      th-abstraction >= 0.5 && < 0.7,
+      th-abstraction >= 0.6 && < 0.7,
       th-orphans >= 0.13.7,
       transformers-compat >= 0.6.3
   default-extensions: TemplateHaskell


### PR DESCRIPTION
Among other changes, there is now a `DTyVarBndrVis` synonym, similar to the existing `DTyVarBndrSpec` and `DTyVarBndrUnit` synonyms, and various types in `Language.Haskell.TH.Desugar.AST` are now defined in terms of `DTyVarBndrVis` instead of `DTyVarBndrUnit`. See the `CHANGES` file for the full details.

This bumps the lower version bounds on `th-abstraction` to `>=0.6`, as this patch makes critical use of several compatibility shims introduced in that version of `th-abstraction`.

Fixes https://github.com/goldfirere/th-desugar/issues/186.