### PR TITLE
Support the `FldName` namespace introduced in GHC 9.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,12 @@ Version 1.16 [????.??.??]
 * `th-desugar` now supports generating typed Template Haskell quotes and splices
   via the new `DTypedBracketE` and `DTypedSpliceE` constructors of `DExp`,
   respectively.
+* The `lookupValueNameWithLocals` function will no longer reify field selectors
+  when the `NoFieldSelectors` language extension is set, mirroring the behavior
+  of the `lookupValueName` function in `template-haskell`. Note that this will
+  only happen when using GHC 9.8 or later, as previous versions of GHC do not
+  equip Template Haskell with enough information to conclude whether a value is
+  a record field or not.
 * The `tupleNameDegree_maybe` function now returns:
   * `Just 0` when the argument is `''Unit`
   * `Just 1` when the argument is `''Solo` or `'MkSolo`

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -49,6 +49,7 @@ import Dec ( RecordSel )
 import ReifyTypeCUSKs
 import ReifyTypeSigs
 import T159Decs ( t159A, t159B )
+import T183 ( t183 )
 import qualified Language.Haskell.TH.Datatype.TyVarBndr as THAbs
 import Language.Haskell.TH.Desugar
 import qualified Language.Haskell.TH.Desugar.OSet as OS
@@ -896,6 +897,9 @@ main = hspec $ do
 #endif
 
     it "locally reifies GADT record selector types with explicit foralls correctly" $ test_t171
+
+    it "doesn't reify a field selector with lookupValueNameWithLocals when NoFieldSelectors is set" $
+      t183 == Nothing
 
     zipWithM (\b n -> it ("recognizes tuple names with tupleDegree_maybe correctly " ++ show n) b)
       test_t187 [1..]

--- a/Test/T183.hs
+++ b/Test/T183.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+#if __GLASGOW_HASKELL__ >= 907
+{-# LANGUAGE NoFieldSelectors #-}
+#endif
+
+-- | A regression test for #T183 which ensures that 'lookupValueNameWithLocals'
+-- does not reify a field selector when the @NoFieldSelectors@ language
+-- extension is set on GHC 9.8 or later. We define this test in its own module
+-- to avoid having to enable @NoFieldSelectors@ in other parts of the test
+-- suite.
+module T183 (t183) where
+
+import Language.Haskell.TH (Name)
+#if __GLASGOW_HASKELL__ >= 907
+import Language.Haskell.TH.Desugar
+#endif
+
+t183 :: Maybe Name
+#if __GLASGOW_HASKELL__ >= 907
+-- This should return 'Nothing', as the 'unT' record should not be made into a
+-- top-level field selector due to @NoFieldSelectors@.
+t183 =
+  $(do decs <- [d| data T = MkT { unT :: Int } |]
+       mbName <- withLocalDeclarations decs (lookupValueNameWithLocals "unT")
+       [| mbName |])
+#else
+-- Lacking @NoFieldSelectors@ on older versions of GHC, we simply hard-code the
+-- result to 'Nothing'.
+t183 = Nothing
+#endif

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -90,6 +90,7 @@ test-suite spec
                       Splices
                       T158Exp
                       T159Decs
+                      T183
 
   build-depends:
       base >= 4 && < 5,


### PR DESCRIPTION
GHC 9.8 now puts record names into the new `FldName` namespace instead of `VarName`. This patch updates `th-desugar` accordingly.

One consequence of supporting `FldName` properly is that the `lookupValueNameWithLocals` function will no longer reify field selectors for record names when `NoFieldSelectors` is set. This is a desirable property, as this mirrors the behavior of the `lookupValueName` function in Template Haskell, thereby fixing https://github.com/goldfirere/th-desugar/issues/183. I've made a note of this change in behavior in the `CHANGES.md` file.

Note that the way we check for `NoFieldSelectors` is somewhat unsatisfactory. As Richard notes in https://github.com/goldfirere/th-desugar/issues/183#issuecomment-1517792696, `th-desugar` can only check for language extensions at the use sites of declarations, whereas it would be better to check for language extensions at definition sites.  Unfortunately, Template Haskell does not offer a way to do the latter, so we have no choice but to do the former.

This isn't really a new thing, since we also make the same compromise when checking for `MonadFailDesugaring` when desugaring partial pattern matches in `do` notation. As a result, I've opted to simpy make a note of this limitation in the `th-desugar` `README`.

Checks off one box in https://github.com/goldfirere/th-desugar/issues/182.