### PR TITLE
Make `extractBoundNamesDPat` no longer extract type variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 `th-desugar` release notes
 ==========================
 
+Version next [????.??.??]
+-------------------------
+* `extractBoundNamesDPat` no longer extracts type variables from constructor
+  patterns. That this function ever did extract type variables was a mistake,
+  and the new behavior of `extractBoundNamesDPat` brings it in line with the
+  behavior `extractBoundNamesPat`.
+
 Version 1.16 [2023.10.13]
 -------------------------
 * Support GHC 9.8.

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -47,13 +47,13 @@ extractBoundNamesDPat :: DPat -> OSet Name
 extractBoundNamesDPat = go
   where
     go :: DPat -> OSet Name
-    go (DLitP _)          = OS.empty
-    go (DVarP n)          = OS.singleton n
+    go (DLitP _)        = OS.empty
+    go (DVarP n)        = OS.singleton n
     go (DConP _ _ pats) = foldMap go pats
-    go (DTildeP p)        = go p
-    go (DBangP p)         = go p
-    go (DSigP p _)        = go p
-    go DWildP             = OS.empty
+    go (DTildeP p)      = go p
+    go (DBangP p)       = go p
+    go (DSigP p _)      = go p
+    go DWildP           = OS.empty
 
 -----
 -- Binding forms

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -41,14 +41,15 @@ fvDType = go
 
 -- | Extract the term variables bound by a 'DPat'.
 --
--- This does /not/ extract any type variables bound by pattern signatures.
+-- This does /not/ extract any type variables bound by pattern signatures or
+-- constructor patterns.
 extractBoundNamesDPat :: DPat -> OSet Name
 extractBoundNamesDPat = go
   where
     go :: DPat -> OSet Name
     go (DLitP _)          = OS.empty
     go (DVarP n)          = OS.singleton n
-    go (DConP _ tys pats) = foldMap fvDType tys <> foldMap go pats
+    go (DConP _ _ pats) = foldMap go pats
     go (DTildeP p)        = go p
     go (DBangP p)         = go p
     go (DSigP p _)        = go p

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -481,7 +481,10 @@ nameOccursIn n = everything (||) $ mkQ False (== n)
 allNamesIn :: Data a => a -> [Name]
 allNamesIn = everything (++) $ mkQ [] (:[])
 
--- | Extract the names bound in a @Stmt@
+-- | Extract the names bound in a @Stmt@.
+--
+-- This does /not/ extract any type variables bound by pattern signatures or
+-- constructor patterns.
 extractBoundNamesStmt :: Stmt -> OSet Name
 extractBoundNamesStmt (BindS pat _) = extractBoundNamesPat pat
 extractBoundNamesStmt (LetS decs)   = foldMap extractBoundNamesDec decs
@@ -492,12 +495,18 @@ extractBoundNamesStmt (RecS stmtss) = foldMap extractBoundNamesStmt stmtss
 #endif
 
 -- | Extract the names bound in a @Dec@ that could appear in a @let@ expression.
+--
+-- This does /not/ extract any type variables bound by pattern signatures or
+-- constructor patterns.
 extractBoundNamesDec :: Dec -> OSet Name
 extractBoundNamesDec (FunD name _)  = OS.singleton name
 extractBoundNamesDec (ValD pat _ _) = extractBoundNamesPat pat
 extractBoundNamesDec _              = OS.empty
 
--- | Extract the names bound in a @Pat@
+-- | Extract the names bound in a @Pat@.
+--
+-- This does /not/ extract any type variables bound by pattern signatures or
+-- constructor patterns.
 extractBoundNamesPat :: Pat -> OSet Name
 extractBoundNamesPat (LitP _)              = OS.empty
 extractBoundNamesPat (VarP name)           = OS.singleton name


### PR DESCRIPTION
The fact that it ever did was an oversight, per the discussion in https://github.com/goldfirere/th-desugar/issues/200. I have clarified the documentation accordingly.

Fixes https://github.com/goldfirere/th-desugar/issues/200.