### PR TITLE
Partial support for embedded types in expressions/patterns and invisible type patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ Version 1.17 [????.??.??]
   clauses of function declarations, but not in lambda expressions, `\case`
   expressions, or `\cases` expressions. See the "Known limitations" section of
   the `th-desugar` `README` for full details.
+* Add partial support for invisible type patterns via the new `DInvisP` data
+  constructor. Just like with `DTypeP`, `th-desugar` only supports the use of
+  `DInvisP` in the clauses of function declarations. See the "Known limitations"
+  section of the `th-desugar` `README` for full details.
 * `extractBoundNamesDPat` no longer extracts type variables from constructor
   patterns. That this function ever did extract type variables was a mistake,
   and the new behavior of `extractBoundNamesDPat` brings it in line with the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ Version 1.17 [????.??.??]
   changes, the `DInfixD` data constructor now has a `NamespaceSpecifier` field.
 * Add support for `SCC` declarations via the new `DSCCP` data constructor for
   the `DPragma` data type.
+* Add partial support for embedded types in expressions (via the new `DTypeE`
+  data constructor) and in patterns (via the new `DTypeP` data constructor).
+  This is only partial support because the use of `DTypeP` is supported in the
+  clauses of function declarations, but not in lambda expressions, `\case`
+  expressions, or `\cases` expressions. See the "Known limitations" section of
+  the `th-desugar` `README` for full details.
 * `extractBoundNamesDPat` no longer extracts type variables from constructor
   patterns. That this function ever did extract type variables was a mistake,
   and the new behavior of `extractBoundNamesDPat` brings it in line with the

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -247,6 +247,7 @@ flattenDValD (DValD pat exp) = do
         DBangP pa -> DBangP (wildify name y pa)
         DSigP pa ty -> DSigP (wildify name y pa) ty
         DWildP -> DWildP
+        DTypeP ty -> DTypeP ty
 
 flattenDValD other_dec = return [other_dec]
 

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -248,6 +248,7 @@ flattenDValD (DValD pat exp) = do
         DSigP pa ty -> DSigP (wildify name y pa) ty
         DWildP -> DWildP
         DTypeP ty -> DTypeP ty
+        DInvisP ty -> DInvisP ty
 
 flattenDValD other_dec = return [other_dec]
 

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -56,6 +56,13 @@ data DPat = DLitP Lit
             -- expressions. See the \"Known limitations\" section of the
             -- @th-desugar@ @README@ for more details.
           | DTypeP DType
+            -- | Note that @th-desugar@ only has partial support for desugaring
+            -- invisible type patterns. In particular, @th-desugar@ supports
+            -- desugaring invisible type patterns in function clauses, but not
+            -- in lambda expressions or @\\cases@ expressions. See the \"Known
+            -- limitations\" section of the @th-desugar@ @README@ for more
+            -- details.
+          | DInvisP DType
           deriving (Eq, Show, Data, Generic, Lift)
 
 -- | Corresponds to TH's @Type@ type, used to represent

--- a/Language/Haskell/TH/Desugar/AST.hs
+++ b/Language/Haskell/TH/Desugar/AST.hs
@@ -37,6 +37,7 @@ data DExp = DVarE Name
           | DStaticE DExp
           | DTypedBracketE DExp
           | DTypedSpliceE DExp
+          | DTypeE DType
           deriving (Eq, Show, Data, Generic, Lift)
 
 
@@ -48,6 +49,13 @@ data DPat = DLitP Lit
           | DBangP DPat
           | DSigP DPat DType
           | DWildP
+            -- | Note that @th-desugar@ only has partial support for desugaring
+            -- embedded type patterns. In particular, @th-desugar@ supports
+            -- desugaring embedded type patterns in function clauses, but not
+            -- in lambda expressions, @\\case@ expressions, or @\\cases@
+            -- expressions. See the \"Known limitations\" section of the
+            -- @th-desugar@ @README@ for more details.
+          | DTypeP DType
           deriving (Eq, Show, Data, Generic, Lift)
 
 -- | Corresponds to TH's @Type@ type, used to represent

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -55,6 +55,7 @@ extractBoundNamesDPat = go
     go (DSigP p _)      = go p
     go DWildP           = OS.empty
     go (DTypeP _)       = OS.empty
+    go (DInvisP _)      = OS.empty
 
 -----
 -- Binding forms

--- a/Language/Haskell/TH/Desugar/FV.hs
+++ b/Language/Haskell/TH/Desugar/FV.hs
@@ -41,8 +41,8 @@ fvDType = go
 
 -- | Extract the term variables bound by a 'DPat'.
 --
--- This does /not/ extract any type variables bound by pattern signatures or
--- constructor patterns.
+-- This does /not/ extract any type variables bound by pattern signatures,
+-- constructor patterns, or type patterns.
 extractBoundNamesDPat :: DPat -> OSet Name
 extractBoundNamesDPat = go
   where
@@ -54,6 +54,7 @@ extractBoundNamesDPat = go
     go (DBangP p)       = go p
     go (DSigP p _)      = go p
     go DWildP           = OS.empty
+    go (DTypeP _)       = OS.empty
 
 -----
 -- Binding forms

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -61,6 +61,7 @@ scExp e@(DVarE {}) = return e
 scExp e@(DConE {}) = return e
 scExp e@(DLitE {}) = return e
 scExp e@(DStaticE {}) = return e
+scExp e@(DTypeE {}) = return e
 
 -- | Like 'scExp', but for a 'DLetDec'.
 scLetDec :: DsMonad q => DLetDec -> q DLetDec
@@ -162,6 +163,7 @@ tidy1 v (DBangP pat) =
     DBangP p  -> tidy1 v (DBangP p) -- discard ! under !
     DSigP p _ -> tidy1 v (DBangP p) -- discard sig under !
     DWildP    -> return (id, DBangP pat)  -- no change
+    DTypeP _  -> return (id, DBangP pat)  -- no change
 tidy1 v (DSigP pat ty)
   | no_tyvars_ty ty = tidy1 v pat
   -- The match-flattener doesn't know how to deal with patterns that mention
@@ -178,6 +180,7 @@ tidy1 v (DSigP pat ty)
     no_tyvar_ty (DVarT{}) = False
     no_tyvar_ty t         = gmapQl (&&) True no_tyvars_ty t
 tidy1 _ DWildP = return (id, DWildP)
+tidy1 _ (DTypeP ty) = return (id, DTypeP ty)
 
 wrapBind :: Name -> Name -> DExp -> DExp
 wrapBind new old
@@ -256,6 +259,7 @@ patGroup (DTildeP {})    = error "Internal error in th-desugar (patGroup DTildeP
 patGroup (DBangP {})     = PgBang
 patGroup (DSigP{})       = error "Internal error in th-desugar (patGroup DSigP)"
 patGroup DWildP          = PgAny
+patGroup (DTypeP {})     = PgAny
 
 sameGroup :: PatGroup -> PatGroup -> Bool
 sameGroup PgAny     PgAny     = True

--- a/Language/Haskell/TH/Desugar/Match.hs
+++ b/Language/Haskell/TH/Desugar/Match.hs
@@ -164,6 +164,7 @@ tidy1 v (DBangP pat) =
     DSigP p _ -> tidy1 v (DBangP p) -- discard sig under !
     DWildP    -> return (id, DBangP pat)  -- no change
     DTypeP _  -> return (id, DBangP pat)  -- no change
+    DInvisP _ -> return (id, DBangP pat)  -- no change
 tidy1 v (DSigP pat ty)
   | no_tyvars_ty ty = tidy1 v pat
   -- The match-flattener doesn't know how to deal with patterns that mention
@@ -181,6 +182,7 @@ tidy1 v (DSigP pat ty)
     no_tyvar_ty t         = gmapQl (&&) True no_tyvars_ty t
 tidy1 _ DWildP = return (id, DWildP)
 tidy1 _ (DTypeP ty) = return (id, DTypeP ty)
+tidy1 _ (DInvisP ty) = return (id, DInvisP ty)
 
 wrapBind :: Name -> Name -> DExp -> DExp
 wrapBind new old
@@ -260,6 +262,7 @@ patGroup (DBangP {})     = PgBang
 patGroup (DSigP{})       = error "Internal error in th-desugar (patGroup DSigP)"
 patGroup DWildP          = PgAny
 patGroup (DTypeP {})     = PgAny
+patGroup (DInvisP {})    = PgAny
 
 sameGroup :: PatGroup -> PatGroup -> Bool
 sameGroup PgAny     PgAny     = True

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -96,9 +96,12 @@ patToTH (DSigP pat ty)      = SigP (patToTH pat) (typeToTH ty)
 patToTH DWildP              = WildP
 #if __GLASGOW_HASKELL__ >= 909
 patToTH (DTypeP ty)         = TypeP (typeToTH ty)
+patToTH (DInvisP ty)        = InvisP (typeToTH ty)
 #else
 patToTH (DTypeP {})         =
   error "Embedded type patterns supported only in GHC 9.10+"
+patToTH (DInvisP {})        =
+  error "Invisible type patterns supported only in GHC 9.10+"
 #endif
 
 decsToTH :: [DDec] -> [Dec]

--- a/Language/Haskell/TH/Desugar/Sweeten.hs
+++ b/Language/Haskell/TH/Desugar/Sweeten.hs
@@ -72,6 +72,12 @@ expToTH (DTypedBracketE {})  =
 expToTH (DTypedSpliceE {})   =
   error "Typed Template Haskell splices supported only in GHC 9.8+"
 #endif
+#if __GLASGOW_HASKELL__ >= 909
+expToTH (DTypeE ty)          = TypeE (typeToTH ty)
+#else
+expToTH (DTypeE {})          =
+  error "Embedded type expressions supported only in GHC 9.10+"
+#endif
 
 matchToTH :: DMatch -> Match
 matchToTH (DMatch pat exp) = Match (patToTH pat) (NormalB (expToTH exp)) []
@@ -88,6 +94,12 @@ patToTH (DTildeP pat)       = TildeP (patToTH pat)
 patToTH (DBangP pat)        = BangP (patToTH pat)
 patToTH (DSigP pat ty)      = SigP (patToTH pat) (typeToTH ty)
 patToTH DWildP              = WildP
+#if __GLASGOW_HASKELL__ >= 909
+patToTH (DTypeP ty)         = TypeP (typeToTH ty)
+#else
+patToTH (DTypeP {})         =
+  error "Embedded type patterns supported only in GHC 9.10+"
+#endif
 
 decsToTH :: [DDec] -> [Dec]
 decsToTH = map decToTH

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -483,8 +483,8 @@ allNamesIn = everything (++) $ mkQ [] (:[])
 
 -- | Extract the names bound in a @Stmt@.
 --
--- This does /not/ extract any type variables bound by pattern signatures or
--- constructor patterns.
+-- This does /not/ extract any type variables bound by pattern signatures,
+-- constructor patterns, or type patterns.
 extractBoundNamesStmt :: Stmt -> OSet Name
 extractBoundNamesStmt (BindS pat _) = extractBoundNamesPat pat
 extractBoundNamesStmt (LetS decs)   = foldMap extractBoundNamesDec decs
@@ -496,8 +496,8 @@ extractBoundNamesStmt (RecS stmtss) = foldMap extractBoundNamesStmt stmtss
 
 -- | Extract the names bound in a @Dec@ that could appear in a @let@ expression.
 --
--- This does /not/ extract any type variables bound by pattern signatures or
--- constructor patterns.
+-- This does /not/ extract any type variables bound by pattern signatures,
+-- constructor patterns, or type patterns.
 extractBoundNamesDec :: Dec -> OSet Name
 extractBoundNamesDec (FunD name _)  = OS.singleton name
 extractBoundNamesDec (ValD pat _ _) = extractBoundNamesPat pat
@@ -505,8 +505,8 @@ extractBoundNamesDec _              = OS.empty
 
 -- | Extract the names bound in a @Pat@.
 --
--- This does /not/ extract any type variables bound by pattern signatures or
--- constructor patterns.
+-- This does /not/ extract any type variables bound by pattern signatures,
+-- constructor patterns, or type patterns.
 extractBoundNamesPat :: Pat -> OSet Name
 extractBoundNamesPat (LitP _)              = OS.empty
 extractBoundNamesPat (VarP name)           = OS.singleton name
@@ -534,6 +534,9 @@ extractBoundNamesPat (SigP pat _)          = extractBoundNamesPat pat
 extractBoundNamesPat (ViewP _ pat)         = extractBoundNamesPat pat
 #if __GLASGOW_HASKELL__ >= 801
 extractBoundNamesPat (UnboxedSumP pat _ _) = extractBoundNamesPat pat
+#endif
+#if __GLASGOW_HASKELL__ >= 909
+extractBoundNamesPat (TypeP _)             = OS.empty
 #endif
 
 ----------------------------------------

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -537,6 +537,7 @@ extractBoundNamesPat (UnboxedSumP pat _ _) = extractBoundNamesPat pat
 #endif
 #if __GLASGOW_HASKELL__ >= 909
 extractBoundNamesPat (TypeP _)             = OS.empty
+extractBoundNamesPat (InvisP _)            = OS.empty
 #endif
 
 ----------------------------------------

--- a/README.md
+++ b/README.md
@@ -211,3 +211,26 @@ declarations, which are fully supported. See also [this `th-desugar`
 issue](https://github.com/goldfirere/th-desugar/issues/210), which proposes a
 different approach to desugaring that would allow all of the examples above to
 be accepted.
+
+## Limited support for invisible type patterns
+
+In GHC 9.10 or later, the `TypeAbstractions` language extension allows one to
+write definitions with invisible type patterns, e.g.,
+
+```hs
+f :: a -> a
+f @a = id @a
+```
+
+`th-desugar` supports writing patterns like `@a` via the `DInvisP` data
+constructor of `DPat`. Be warned, however, that `th-desugar` only supports
+desugaring `DInvisP` in the clauses of function declarations, such as the
+declaration of `f` above. As a result, `th-desugar` does not support desugaring
+`DInvisP` in any other position, such as lambda expressions or `\cases`
+expressions.
+
+Ultimately, this limitation has the same underlying cause as `th-desugar`'s
+limitations surrounding embedded types in patterns (see the "Limited support
+for embedded types in patterns" section above). As a result, the same
+workaround applies: convert uses of lambdas and `LambdaCase` to function
+declarations, which are fully supported.

--- a/README.md
+++ b/README.md
@@ -144,3 +144,70 @@ normal function arrow `(->)`. This choice is partly motivated by issues in the
 way that linear types interact with Template Haskell, which sometimes make it
 impossible to tell whether a reified function type is linear or not. See, for
 instance, [GHC#18378](https://gitlab.haskell.org/ghc/ghc/-/issues/18378).
+
+## Limited support for embedded types in patterns
+
+In GHC 9.10 or later, the `RequiredTypeArguments` language extension allows one
+to write definitions with embedded types in patterns, e.g.,
+
+```hs
+idv :: forall a -> a -> a
+idv (type a) = id @a
+```
+
+`th-desugar` supports writing patterns like `(type a)` via the `DTypeP` data
+constructor of `DPat`. Be warned, however, that `th-desugar` only supports
+desugaring `DTypeP` in the clauses of function declarations, such as the
+declaration of `idv` above. As a result, `th-desugar` does not support
+desugaring `DTypeP` in any other position, including:
+
+* Lambda expressions. For example, the following is not supported:
+
+  ```hs
+  idv2 :: forall a -> a -> a
+  idv2 = \(type a) -> id @a
+  ```
+* `\case` expressions. For example, the following is not supported:
+
+  ```hs
+  idv3 :: forall a -> a -> a
+  idv3 = \case
+    (type a) -> id @a
+  ```
+* `\cases` expressions. For example, the following is not supported:
+
+  ```hs
+  idv4 :: forall a -> a -> a
+  idv4 = \cases
+    (type a) x -> x :: a
+  ```
+
+Note that all of the example above use an explicit `type` keyword, but the same
+considerations apply for embedded type patterns that do not use the `type`
+keyword. That is, `th-desugar` supports desugaring the following:
+
+```hs
+idv' :: forall a -> a -> a
+idv' a = id @a
+```
+
+But `th-desugar` does not support desugaring any of the following:
+
+```hs
+idv2' :: forall a -> a -> a
+idv2' = \a -> id @a
+
+idv3' :: forall a -> a -> a
+idv3' = \case
+  a -> id @a
+
+idv4' :: forall a -> a -> a
+idv4' = \cases
+  a x -> x :: a
+```
+
+As a workaround, one can convert uses of lambdas and `LambdaCase` to function
+declarations, which are fully supported. See also [this `th-desugar`
+issue](https://github.com/goldfirere/th-desugar/issues/210), which proposes a
+different approach to desugaring that would allow all of the examples above to
+be accepted.

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -38,6 +38,10 @@ rae@cs.brynmawr.edu
 {-# LANGUAGE TypeAbstractions #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 909
+{-# LANGUAGE RequiredTypeArguments #-}
+#endif
+
 module Main where
 
 import Prelude hiding ( exp )
@@ -179,6 +183,10 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
 #if __GLASGOW_HASKELL__ >= 907
              , "typed_th_bracket" ~: $$($test57_typed_th_bracket) @=? $$($(dsSplice test57_typed_th_bracket))
              , "typed_th_splice" ~: $test58_typed_th_splice @=? $(dsSplice test58_typed_th_splice)
+#endif
+#if __GLASGOW_HASKELL__ >= 909
+             , "embedded_types_keyword" ~: $test59_embedded_types_keyword @=? $(dsSplice test59_embedded_types_keyword)
+             , "embedded_types_no_keyword" ~: $test60_embedded_types_no_keyword @=? $(dsSplice test60_embedded_types_no_keyword)
 #endif
              ]
 

--- a/Test/Run.hs
+++ b/Test/Run.hs
@@ -187,6 +187,7 @@ tests = test [ "sections" ~: $test1_sections  @=? $(dsSplice test1_sections)
 #if __GLASGOW_HASKELL__ >= 909
              , "embedded_types_keyword" ~: $test59_embedded_types_keyword @=? $(dsSplice test59_embedded_types_keyword)
              , "embedded_types_no_keyword" ~: $test60_embedded_types_no_keyword @=? $(dsSplice test60_embedded_types_no_keyword)
+             , "invis_type_pat" ~: $test61_invis_type_pat @=? $(dsSplice test61_invis_type_pat)
 #endif
              ]
 

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -407,6 +407,12 @@ test60_embedded_types_no_keyword =
          idv a (x :: a) = x :: a
 
      in idv Bool True |]
+
+test61_invis_type_pat =
+  [| let f :: a -> a
+         f @a = id @a
+
+     in f @Bool True |]
 #endif
 
 type family TFExpand x
@@ -877,5 +883,6 @@ test_exprs = [ test1_sections
 #if __GLASGOW_HASKELL__ >= 909
              , test59_embedded_types_keyword
              , test60_embedded_types_no_keyword
+             , test61_invis_type_pat
 #endif
              ]

--- a/Test/Splices.hs
+++ b/Test/Splices.hs
@@ -57,6 +57,10 @@ rae@cs.brynmawr.edu
 {-# LANGUAGE TypeAbstractions #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 909
+{-# LANGUAGE RequiredTypeArguments #-}
+#endif
+
 {-# OPTIONS_GHC -Wno-missing-signatures -Wno-type-defaults
                 -Wno-name-shadowing #-}
 
@@ -389,6 +393,20 @@ test57_typed_th_bracket =
 
 test58_typed_th_splice =
   typedSpliceE (typedBracketE [| 'y' |])
+#endif
+
+#if __GLASGOW_HASKELL__ >= 909
+test59_embedded_types_keyword =
+  [| let idv :: forall a -> a -> a
+         idv (type a) (x :: a) = x :: a
+
+     in idv (type Bool) True |]
+
+test60_embedded_types_no_keyword =
+  [| let idv :: forall a -> a -> a
+         idv a (x :: a) = x :: a
+
+     in idv Bool True |]
 #endif
 
 type family TFExpand x
@@ -855,5 +873,9 @@ test_exprs = [ test1_sections
 #if __GLASGOW_HASKELL__ >= 907
              , test57_typed_th_bracket
              , test58_typed_th_splice
+#endif
+#if __GLASGOW_HASKELL__ >= 909
+             , test59_embedded_types_keyword
+             , test60_embedded_types_no_keyword
 #endif
              ]


### PR DESCRIPTION
This is a partial fix for #204 and #205 which adds `DTypeE`, `DTypeP`, and `DInvisP` constructs to the `th-desugar` AST, which behave exactly like their `TypeE`, `TypeP`, and `InvisP` counterparts in the `template-haskell` AST. This is only a partial fix, however, because `DTypeP` and `DInvisP` are currently only supported in the clauses of function declarations. In particular, `DTypeP` and `DInvisP` are _not_ supported in lambda expressions, `\case` expressions, or `\cases` expressions. See the "Known limitations" section of the `README` for more.

In order to add full support for `DTypeP` and `DInvisP`, we would first need to implement the design proposed in https://github.com/goldfirere/th-desugar/issues/210. Until then, this is good enough.