### PR TITLE
Make `unboxed{Tuple,Sum}NameDegree_maybe` work with GHC 9.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,17 @@ Version 1.17 [????.??.??]
   patterns. That this function ever did extract type variables was a mistake,
   and the new behavior of `extractBoundNamesDPat` brings it in line with the
   behavior `extractBoundNamesPat`.
+* The `unboxedTupleNameDegree_maybe` function now returns:
+  * `Just 0` when the argument is `''Unit#`
+  * `Just 1` when the argument is `''Solo#`
+  * `Just <N>` when the argument is `''Tuple<N>#`
+  This is primarily motivated by the fact that with GHC 9.10 or later, `''(##)`
+  is syntactic sugar for `''Unit#`, `''(#,#)` is syntactic sugar for `Tuple2#`,
+  and so on.
+* The `unboxedSumNameDegree_maybe` function now returns `Just n` when the
+  argument is `Sum<N>#`. This is primarily motivated by the fact that with GHC
+  9.10 or later, `''(#|#)` is syntactic sugar for `Sum2#`, `''(#||#)` is
+  syntactic sugar for `Sum3#`, and so on.
 * Add `Foldable` and `Traversable` instances for `DTyVarBndrSpec`.
 
 Version 1.16 [2023.10.13]

--- a/Test/FakeSums.hs
+++ b/Test/FakeSums.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE MagicHash #-}
+
+-- | Defines data types with names identical to those found in "GHC.Types".
+-- This is used as part of a series of unit tests for the
+-- @unboxedSumNameDegree_maybe@ function, which should only return 'Just' when the
+-- argument 'Name' is actually an unboxed sum from "GHC.Types", not a user-defined
+-- type.
+module FakeSums
+  ( Sum2#, Sum3#, Sum4#
+  ) where
+
+data Sum2# a b
+data Sum3# a b c
+data Sum4# a b c

--- a/Test/FakeTuples.hs
+++ b/Test/FakeTuples.hs
@@ -1,13 +1,21 @@
+{-# LANGUAGE MagicHash #-}
+
 -- | Defines data types with names identical to those found in "GHC.Tuple".
 -- This is used as part of a series of unit tests for the
--- @tupleNameDegree_maybe@ function, which should only return 'Just' when the
--- argument 'Name' is actually a tuple from "GHC.Tuple", not a user-defined
--- type.
+-- @tupleNameDegree_maybe@ and @unboxedTupleNameDegree_maybe@ functions, which
+-- should only return 'Just' when the argument 'Name' is actually a tuple from
+-- "GHC.Tuple", not a user-defined type.
 module FakeTuples
-  ( Tuple0, Tuple1, Tuple2, Tuple3
+  ( Tuple0,  Tuple1,  Tuple2,  Tuple3
+  , Tuple0#, Tuple1#, Tuple2#, Tuple3#
   ) where
 
 data Tuple0
 data Tuple1 a
 data Tuple2 a b
 data Tuple3 a b c
+
+data Tuple0#
+data Tuple1# a
+data Tuple2# a b
+data Tuple3# a b c

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -85,6 +85,7 @@ test-suite spec
   main-is:            Run.hs
   other-modules:      Dec
                       DsDec
+                      FakeSums
                       FakeTuples
                       ReifyTypeCUSKs
                       ReifyTypeSigs


### PR DESCRIPTION
This patch changes `unboxedTupleNameDegree_maybe` to handle non-punning tuple names introduced in GHC 9.10, such as `Unit#`, `Solo#`, `Tuple2#`, `Tuple3#`, etc. This is because `''(##)` is now syntactic sugar for `''Unit#`, `''(#,#)` is now syntactic sugar for `Tuple2#`, and so on, so it is important to be able to recognize both forms.

Similarly, this patch changes `unboxedSumNameDegree_maybe` to handle `Sum2#`, `Sum3#`, etc.

Fixes #213.