### PR TITLE
Add `LamCaseAlt` to `MatchContext`, make `dsMatches` use `MatchContext`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 `th-desugar` release notes
 ==========================
 
+Version 1.18 [????.??.??]
+-------------------------
+* The `dsMatches` function now requires a `MatchContext` argument, which
+  determines what kind of "`Non-exhaustive patterns in ...`" error it raises
+  when reaching a fallthrough case for non-exhaustive matches.
+
 Version 1.17 [2024.05.12]
 -------------------------
 * Support GHC 9.10.

--- a/Language/Haskell/TH/Desugar.hs
+++ b/Language/Haskell/TH/Desugar.hs
@@ -57,6 +57,7 @@ module Language.Haskell.TH.Desugar (
   -- ** Secondary desugaring functions
   PatM, dsPred, dsPat, dsDec, dsDataDec, dsDataInstDec,
   DerivingClause, dsDerivClause, dsLetDec,
+  MatchContext(..), LamCaseVariant(..),
   dsMatches, dsBody, dsGuards, dsDoStmts, dsComp, dsClauses,
   dsBangType, dsVarBangType,
   dsTypeFamilyHead, dsFamilyResultSig,

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -1,5 +1,5 @@
 name:           th-desugar
-version:        1.17
+version:        1.18
 cabal-version:  >= 1.10
 synopsis:       Functions to desugar Template Haskell
 homepage:       https://github.com/goldfirere/th-desugar


### PR DESCRIPTION
This patch:

* Adds a `LamCaseAlt` data constructor to `MatchContext`, which allows non-exhaustive `\case`/`\cases` expressions to indicate that they actually arose from `\case`/`\cases` expressions, rather than erroneously reporting that they arose from a `case` expression (as reported in #217). The auxiliary `LamCaseVariant` data type is used to tell `\case`/`\cases` apart specifically, exactly like how it is done in GHC.
* Exports `MatchContext` (as well as `LamCaseVariant`) from `L.H.TH.Desugar`. I should have done this back in #160, but I forgot to do this due to an oversight.
* Makes `dsMatches` accept a `MatchContext` argument so that desugared `\case`/`\cases` expressions can actually make use of `LamCaseAlt`. This brings the type signature for `dsMatches` closer in line to its sibling function `dsClauses`, which is a good thing.

Fixes #217.