### PR TITLE
Add a `Quote` instance for `DsM`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Version 1.18 [????.??.??]
 * Add support for desugaring higher-order uses of embedded type patterns (e.g.,
   `\(type a) (x :: a) -> x :: a`) and invisible type patterns (e.g.,
   `\ @a (x :: a) -> x :: a`).
+* Add a `Quote` instance for `DsM`.
 
 Version 1.17 [2024.05.12]
 -------------------------

--- a/Language/Haskell/TH/Desugar/Reify.hs
+++ b/Language/Haskell/TH/Desugar/Reify.hs
@@ -53,6 +53,7 @@ import Language.Haskell.TH.Datatype ( freeVariables, freeVariablesWellScoped
 import Language.Haskell.TH.Datatype.TyVarBndr
 import Language.Haskell.TH.Instances ()
 import Language.Haskell.TH.Syntax hiding ( lift )
+import qualified Language.Haskell.TH.Syntax.Compat as Compat ( Quote )
 
 import Language.Haskell.TH.Desugar.Util as Util
 
@@ -202,7 +203,8 @@ instance DsMonad IO where
 -- | A convenient implementation of the 'DsMonad' class. Use by calling
 -- 'withLocalDeclarations'.
 newtype DsM q a = DsM (ReaderT [Dec] q a)
-  deriving ( Functor, Applicative, Monad, MonadTrans, Quasi, Fail.MonadFail
+  deriving ( Functor, Applicative, Monad, MonadTrans, Fail.MonadFail
+           , Quasi, Compat.Quote
 #if __GLASGOW_HASKELL__ >= 803
            , MonadIO
 #endif

--- a/th-desugar.cabal
+++ b/th-desugar.cabal
@@ -55,7 +55,8 @@ library
       ordered-containers >= 0.2.2,
       syb >= 0.4,
       th-abstraction >= 0.6 && < 0.8,
-      th-orphans >= 0.13.7,
+      th-compat >= 0.1 && < 0.2,
+      th-orphans >= 0.13.11,
       transformers-compat >= 0.6.3
   default-extensions: TemplateHaskell
   exposed-modules:    Language.Haskell.TH.Desugar
@@ -105,4 +106,4 @@ test-suite spec
       hspec >= 1.3,
       th-abstraction,
       th-desugar,
-      th-orphans >= 0.13.9
+      th-orphans


### PR DESCRIPTION
To ensure that this instance will work on pre-9.0 versions of GHC, we import the `Quote` class from the `th-compat` package, which backports `Quote` to old GHCs.

Fixes #225.