### PR TITLE
Adapt to (but don't support) or-patterns

### DIFF
--- a/Language/Haskell/TH/Desugar/Core.hs
+++ b/Language/Haskell/TH/Desugar/Core.hs
@@ -694,6 +694,10 @@ dsPat (InvisP ty) = DInvisP <$> dsType ty
 #endif
 dsPat (ViewP _ _) =
   fail "View patterns are not supported in th-desugar. Use pattern guards instead."
+#if __GLASGOW_HASKELL__ >= 911
+dsPat (OrP _) =
+  fail "Or-patterns are not supported in th-desugar."
+#endif
 
 -- | Convert a 'DPat' to a 'DExp'. Fails on 'DWildP' and 'DInvisP'.
 dPatToDExp :: DPat -> DExp

--- a/Language/Haskell/TH/Desugar/Util.hs
+++ b/Language/Haskell/TH/Desugar/Util.hs
@@ -1113,6 +1113,9 @@ extractBoundNamesPat (UnboxedSumP pat _ _) = extractBoundNamesPat pat
 extractBoundNamesPat (TypeP _)             = OS.empty
 extractBoundNamesPat (InvisP _)            = OS.empty
 #endif
+#if __GLASGOW_HASKELL__ >= 911
+extractBoundNamesPat (OrP pats)            = foldMap extractBoundNamesPat pats
+#endif
 
 ----------------------------------------
 -- General utility

--- a/README.md
+++ b/README.md
@@ -371,6 +371,13 @@ Currently, there is not a viable workaround for using view patterns in pattern
 synonym definitions—see [this `th-desugar`
 issue](https://github.com/goldfirere/th-desugar/issues/174).
 
+## No support for or-patterns
+
+`th-desugar` does not support desugaring
+[or-patterns](https://github.com/ghc-proposals/ghc-proposals/blob/c9401f037cb22d1661931b2ec621925101052997/proposals/0522-or-patterns.rst).
+See [this `th-desugar`
+issue](https://github.com/goldfirere/th-desugar/issues/232).
+
 ## No support for `ApplicativeDo`
 
 `th-desugar` does not take the `ApplicativeDo` extension into account when


### PR DESCRIPTION
Handling or-patterns in full generality is tricky (see #232), so for now, we simply error if we attempt to desugar an or-pattern.

Checks off one box in #231.